### PR TITLE
Improve the handling of rules engine subclasses

### DIFF
--- a/easyrules-core/src/main/java/org/easyrules/core/RulesEngineBuilder.java
+++ b/easyrules-core/src/main/java/org/easyrules/core/RulesEngineBuilder.java
@@ -104,7 +104,7 @@ public class RulesEngineBuilder<E extends RulesEngine> {
     public E build() {
         try {
             return this.getRulesEngineConstructors().newInstance(parameters, ruleListeners);
-        } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException exception) {
+        } catch (Exception exception) {
             throw new EngineInstantiationException("Cannot instantiate the new rules engine", exception);
         }
     }

--- a/easyrules-core/src/main/java/org/easyrules/core/RulesEngineBuilder.java
+++ b/easyrules-core/src/main/java/org/easyrules/core/RulesEngineBuilder.java
@@ -4,6 +4,8 @@ import org.easyrules.api.RuleListener;
 import org.easyrules.api.RulesEngine;
 import org.easyrules.util.Utils;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -12,58 +14,125 @@ import java.util.List;
  *
  * @author Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  */
-public class RulesEngineBuilder {
+public class RulesEngineBuilder<E extends RulesEngine> {
+
+    public static class EngineInstantiationException extends RuntimeException {
+        private static final long serialVersionUID = -7927944703782618629L;
+
+        /**
+         * Constructs a new exception with the specified detail message. The cause is not initialized, and may subsequently be initialized by a call to {@link #initCause}.
+         *
+         * @param message
+         *            the detail message. The detail message is saved for later retrieval by the {@link #getMessage()} method.
+         */
+        public EngineInstantiationException(String message) {
+            super(message);
+        }
+
+        /**
+         * Constructs a new exception with the specified detail message and cause.
+         * <p>
+         * Note that the detail message associated with {@code cause} is <i>not</i> automatically incorporated in this exception's detail message.
+         *
+         * @param message
+         *            the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+         * @param cause
+         *            the cause (which is saved for later retrieval by the {@link #getCause()} method). (A <tt>null</tt> value is permitted, and indicates that the cause is
+         *            nonexistent or unknown.)
+         */
+        public EngineInstantiationException(String message, Throwable cause) {
+            super(message, cause);
+        }
+
+    }
 
     private RulesEngineParameters parameters;
 
     private List<RuleListener> ruleListeners;
 
-    public static RulesEngineBuilder aNewRulesEngine() {
-        return new RulesEngineBuilder();
+    private Class<E> rulesEngineClass;
+
+    public static RulesEngineBuilder<DefaultRulesEngine> aNewRulesEngine() {
+        return new RulesEngineBuilder<DefaultRulesEngine>(DefaultRulesEngine.class);
     }
 
-    private RulesEngineBuilder() {
-        parameters = new RulesEngineParameters(Utils.DEFAULT_ENGINE_NAME, false, false, Utils.DEFAULT_RULE_PRIORITY_THRESHOLD, false);
-        ruleListeners = new ArrayList<>();
+    public static <E extends RulesEngine> RulesEngineBuilder<E> aNewRulesEngine(Class<E> rulesEngineClass) {
+        return new RulesEngineBuilder<E>(rulesEngineClass);
     }
 
-    public RulesEngineBuilder named(final String name) {
+    private RulesEngineBuilder(Class<E> rulesEngineClass) {
+        this.parameters = new RulesEngineParameters(Utils.DEFAULT_ENGINE_NAME, false, false, Utils.DEFAULT_RULE_PRIORITY_THRESHOLD, false);
+        this.ruleListeners = new ArrayList<>();
+        this.rulesEngineClass = rulesEngineClass;
+    }
+
+    public RulesEngineBuilder<E> named(final String name) {
         parameters.setName(name);
         return this;
     }
 
-    public RulesEngineBuilder withSkipOnFirstAppliedRule(final boolean skipOnFirstAppliedRule) {
+    public RulesEngineBuilder<E> withSkipOnFirstAppliedRule(final boolean skipOnFirstAppliedRule) {
         parameters.setSkipOnFirstAppliedRule(skipOnFirstAppliedRule);
         return this;
     }
 
-    public RulesEngineBuilder withSkipOnFirstNonTriggeredRule(final boolean skipOnFirstNonTriggeredRule) {
+    public RulesEngineBuilder<E> withSkipOnFirstNonTriggeredRule(final boolean skipOnFirstNonTriggeredRule) {
         parameters.setSkipOnFirstNonTriggeredRule(skipOnFirstNonTriggeredRule);
         return this;
     }
 
-    public RulesEngineBuilder withSkipOnFirstFailedRule(final boolean skipOnFirstFailedRule) {
+    public RulesEngineBuilder<E> withSkipOnFirstFailedRule(final boolean skipOnFirstFailedRule) {
         parameters.setSkipOnFirstFailedRule(skipOnFirstFailedRule);
         return this;
     }
 
-    public RulesEngineBuilder withRulePriorityThreshold(final int priorityThreshold) {
+    public RulesEngineBuilder<E> withRulePriorityThreshold(final int priorityThreshold) {
         parameters.setPriorityThreshold(priorityThreshold);
         return this;
     }
 
-    public RulesEngineBuilder withRuleListener(final RuleListener ruleListener) {
+    public RulesEngineBuilder<E> withRuleListener(final RuleListener ruleListener) {
         this.ruleListeners.add(ruleListener);
         return this;
     }
 
-    public RulesEngineBuilder withSilentMode(final boolean silentMode) {
+    public RulesEngineBuilder<E> withSilentMode(final boolean silentMode) {
         parameters.setSilentMode(silentMode);
         return this;
     }
 
-    public RulesEngine build() {
-        return new DefaultRulesEngine(parameters, ruleListeners);
+    public E build() {
+        try {
+            return this.getRulesEngineConstructors().newInstance(parameters, ruleListeners);
+        } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException exception) {
+            throw new EngineInstantiationException("Cannot instantiate the new rules engine", exception);
+        }
+    }
+
+    /**
+     * Search the rules engine class for the appropriate constructor for the new rules engine
+     * 
+     * @return rules engine constructor
+     * @throws SecurityException
+     * @throws NoSuchMethodException
+     */
+    @SuppressWarnings("unchecked")
+    protected Constructor<E> getRulesEngineConstructors() throws SecurityException, NoSuchMethodException {
+        Constructor<?> constructor = null;
+        for (Constructor<?> aConstructor : this.rulesEngineClass.getDeclaredConstructors()) {
+            Class<?>[] parameters = aConstructor.getParameterTypes();
+            if ((parameters.length == 2) && RulesEngineParameters.class.isAssignableFrom(parameters[0]) && List.class.isAssignableFrom(parameters[1])) {
+                constructor = aConstructor;
+                break;
+            }
+        }
+        if (constructor == null) {
+            throw new NoSuchMethodException("Cannot find a constructor for the rules engine class " + this.rulesEngineClass);
+        }
+        if (!constructor.isAccessible()) {
+            constructor.setAccessible(true);
+        }
+        return (Constructor<E>) constructor;
     }
 
 }

--- a/easyrules-core/src/test/java/org/easyrules/core/RulesEngineBuilderTest.java
+++ b/easyrules-core/src/test/java/org/easyrules/core/RulesEngineBuilderTest.java
@@ -1,0 +1,40 @@
+package org.easyrules.core;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.easyrules.api.RuleListener;
+import org.easyrules.api.RulesEngine;
+import org.junit.Test;
+
+/**
+ * Test class for {@link org.easyrules.core.RulesEngineBuilder}.
+ *
+ * @author Pierre Frisch (pierre.frisch@spearway.com)
+ */
+public class RulesEngineBuilderTest {
+    public static class MyRulesEngine extends DefaultRulesEngine {
+
+        MyRulesEngine(RulesEngineParameters parameters, List<RuleListener> ruleListeners) {
+            super(parameters, ruleListeners);
+        }
+
+    }
+
+    @Test
+    public void checkLegacyRulesEngineBuilderSyntax() throws Exception {
+        RulesEngine engine = RulesEngineBuilder.aNewRulesEngine().build();
+        assertNotNull("Created legacy rule engine", engine);
+        assertTrue("Created parametrized rule engine of class DefaultRulesEngine", engine instanceof DefaultRulesEngine);
+    }
+
+    @Test
+    public void checkParametrisedRulesEngineBuilderSyntax() throws Exception {
+        RulesEngine engine = RulesEngineBuilder.aNewRulesEngine(MyRulesEngine.class).build();
+        assertNotNull("Created parametrized rule engine", engine);
+        assertTrue("Created parametrized rule engine of class MyRulesEngine", engine instanceof MyRulesEngine);
+    }
+
+}

--- a/easyrules-core/src/test/java/org/easyrules/core/RulesEngineBuilderTest.java
+++ b/easyrules-core/src/test/java/org/easyrules/core/RulesEngineBuilderTest.java
@@ -2,6 +2,7 @@ package org.easyrules.core;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.List;
 
@@ -23,6 +24,22 @@ public class RulesEngineBuilderTest {
 
     }
 
+    public static class BogusRulesEngine extends DefaultRulesEngine {
+
+        BogusRulesEngine() {
+            super(null, null);
+        }
+
+    }
+
+    public static class PrivateRulesEngine extends DefaultRulesEngine {
+
+        private PrivateRulesEngine(RulesEngineParameters parameters, List<RuleListener> ruleListeners) {
+            super(parameters, ruleListeners);
+        }
+
+    }
+
     @Test
     public void checkLegacyRulesEngineBuilderSyntax() throws Exception {
         RulesEngine engine = RulesEngineBuilder.aNewRulesEngine().build();
@@ -35,6 +52,22 @@ public class RulesEngineBuilderTest {
         RulesEngine engine = RulesEngineBuilder.aNewRulesEngine(MyRulesEngine.class).build();
         assertNotNull("Created parametrized rule engine", engine);
         assertTrue("Created parametrized rule engine of class MyRulesEngine", engine instanceof MyRulesEngine);
+    }
+
+    @Test
+    public void checkBogusRulesEngineBuilderSyntax() throws RuntimeException {
+        try {
+            RulesEngineBuilder.aNewRulesEngine(BogusRulesEngine.class).build();
+            fail("Should not have created a bogus engine");
+        } catch (RuntimeException exception) {
+        }
+    }
+
+    @Test
+    public void checkPrivateRulesEngineBuilderSyntax() throws RuntimeException {
+        RulesEngine engine = RulesEngineBuilder.aNewRulesEngine(PrivateRulesEngine.class).build();
+        assertNotNull("Created private parametrized rule engine", engine);
+        assertTrue("Created private parametrized rule engine of class PrivateRulesEngine", engine instanceof PrivateRulesEngine);
     }
 
 }

--- a/easyrules-spring/src/main/java/org/easyrules/spring/RulesEngineFactoryBean.java
+++ b/easyrules-spring/src/main/java/org/easyrules/spring/RulesEngineFactoryBean.java
@@ -59,7 +59,7 @@ public class RulesEngineFactoryBean implements FactoryBean<RulesEngine> {
 
     @Override
     public RulesEngine getObject() {
-        RulesEngineBuilder rulesEngineBuilder = aNewRulesEngine()
+        RulesEngineBuilder<?> rulesEngineBuilder = aNewRulesEngine()
                 .named(name)
                 .withSkipOnFirstAppliedRule(skipOnFirstAppliedRule)
                 .withSkipOnFirstNonTriggeredRule(skipOnFirstNonTriggeredRule)
@@ -90,7 +90,7 @@ public class RulesEngineFactoryBean implements FactoryBean<RulesEngine> {
         }
     }
 
-    private void registerRuleListeners(RulesEngineBuilder rulesEngineBuilder) {
+    private void registerRuleListeners(RulesEngineBuilder<?> rulesEngineBuilder) {
         if (ruleListeners != null && !ruleListeners.isEmpty()) {
             for (RuleListener ruleListener : ruleListeners) {
                 rulesEngineBuilder.withRuleListener(ruleListener);


### PR DESCRIPTION
This should enable better subclassing of the rule engine. 

Existing code should only see an added warning and no breakage (see unit test).