### PR TITLE
A little optimization in RuleProxy.java 

### DIFF
--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/RuleProxy.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/RuleProxy.java
@@ -144,16 +144,15 @@ public class RuleProxy implements InvocationHandler {
     }
 
     private int compareTo(final Rule otherRule) throws Exception {
-        String otherName = otherRule.getName();
         int otherPriority = otherRule.getPriority();
-        String name = getRuleName();
         int priority = getRulePriority();
-
         if (priority < otherPriority) {
             return -1;
         } else if (priority > otherPriority) {
             return 1;
         } else {
+            String otherName = otherRule.getName();
+            String name = getRuleName();
             return name.compareTo(otherName);
         }
     }

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/RuleProxy.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/RuleProxy.java
@@ -163,7 +163,7 @@ public class RuleProxy implements InvocationHandler {
         Method[] methods = getMethods();
         for (Method method : methods) {
             if (method.isAnnotationPresent(Priority.class)) {
-                priority = (Integer) method.invoke(target);
+                priority = (int) method.invoke(target);
                 break;
             }
         }


### PR DESCRIPTION
1. lazy-init names
Only a very few cases need to compare *RuleA* to *RuleB* by `name`.  So lazy-init `name` will get a better performance. On the other hand, I have to say  the method `compareTo()` has been called too many times, because `Set<Rule>` is a `TreeSet`,  `compareTo()` will be called while register or unregister a new rule. So that lazy-init is more necessary.

2. convert `Integer` to` int`
First of all, `priority` does not need `Integer`,  `int` is enough. With `Integer`, it will bring unnecessary cost of *Autoboxing* and *Unboxing*