### PR TITLE
Improve the Facts api

### DIFF
--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/Facts.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/Facts.java
@@ -42,20 +42,28 @@ public class Facts implements Iterable<Map.Entry<String, Object>> {
      *
      * @param name fact name
      * @param fact object to put in the working memory
+     * @return the previous value associated with <tt>name</tt>, or
+     *         <tt>null</tt> if there was no mapping for <tt>name</tt>.
+     *         (A <tt>null</tt> return can also indicate that the map
+     *         previously associated <tt>null</tt> with <tt>name</tt>.)
      */
-    public void put(String name, Object fact) {
+    public Object put(String name, Object fact) {
         Objects.requireNonNull(name);
-        facts.put(name, fact);
+        return facts.put(name, fact);
     }
 
     /**
      * Remove fact.
      *
      * @param name of fact to remove
+     * @return the previous value associated with <tt>name</tt>, or
+     *         <tt>null</tt> if there was no mapping for <tt>name</tt>.
+     *         (A <tt>null</tt> return can also indicate that the map
+     *         previously associated <tt>null</tt> with <tt>name</tt>.)
      */
-    public void remove(String name) {
+    public Object remove(String name) {
         Objects.requireNonNull(name);
-        facts.remove(name);
+        return facts.remove(name);
     }
 
     /**
@@ -67,6 +75,15 @@ public class Facts implements Iterable<Map.Entry<String, Object>> {
     public Object get(String name) {
         Objects.requireNonNull(name);
         return facts.get(name);
+    }
+
+    /**
+     * Return facts as a map.
+     *
+     * @return the current facts as a {@link HashMap}
+     */
+    public Map<String, Object> asMap() {
+        return facts;
     }
 
     @Override

--- a/easy-rules-core/src/test/java/org/jeasy/rules/api/FactsTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/api/FactsTest.java
@@ -25,6 +25,8 @@ package org.jeasy.rules.api;
 
 import org.junit.Test;
 
+import java.util.HashMap;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class FactsTest {
@@ -41,6 +43,15 @@ public class FactsTest {
     }
 
     @Test
+    public void returnOfPut() {
+        Object o1 = facts.put("foo", 1);
+        Object o2 = facts.put("foo", 2);
+
+        assertThat(o1).isEqualTo(null);
+        assertThat(o2).isEqualTo(1);
+    }
+
+    @Test
     public void remove() throws Exception {
         facts.put("foo", 1);
         facts.remove("foo");
@@ -49,9 +60,25 @@ public class FactsTest {
     }
 
     @Test
+    public void returnOfRemove() {
+        facts.put("foo", 1);
+        Object o1 = facts.remove("foo");
+        Object o2 = facts.remove("bar");
+
+        assertThat(o1).isEqualTo(1);
+        assertThat(o2).isEqualTo(null);
+    }
+
+    @Test
     public void get() throws Exception {
         facts.put("foo", 1);
         assertThat(facts.get("foo")).isEqualTo(1);
+    }
+
+    @Test
+    public void asMap() {
+        Object o = facts.asMap();
+        assertThat(o instanceof HashMap).isTrue();
     }
 
     @Test(expected = NullPointerException.class)


### PR DESCRIPTION
1. Change the return type of `put` and `remove` from **`void`** to **`Object`**. It's similar to `Map`. Base on an object, it will get more flexible with processing the return value, especially while you want to get the previous value  with the method `remove`.

2. Add method `asMap()` to get `facts` as an origin `Map`, so that it become easy to conver `Facts` to `Map`.
 
BTW, did you see the example I have commented in #94 @benas ?
Here is the sample https://gist.github.com/wg1j/335dfe2135524a5a99124fd7edad6f79#file-expressionrule-java-L56 😄
