### PR TITLE
[subFacts]: Conditions or Actions can have subclass of Facts as parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ For any further question, you can use the [Gitter](https://gitter.im/j-easy/easy
 * [vinoct6](https://github.com/vinoct6)
 * [wg1j](https://github.com/wg1j)
 * [will-gilbert](https://github.com/will-gilbert)
+* [sanmibuh](https://github.com/sanmibuh)
 
 Thank you all for your contributions!
 

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/RuleDefinitionValidator.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/RuleDefinitionValidator.java
@@ -23,16 +23,19 @@
  */
 package org.jeasy.rules.core;
 
-import org.jeasy.rules.annotation.*;
-import org.jeasy.rules.api.Facts;
+import static java.lang.String.format;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
-
-import static java.lang.String.format;
+import org.jeasy.rules.annotation.Action;
+import org.jeasy.rules.annotation.Condition;
+import org.jeasy.rules.annotation.Fact;
+import org.jeasy.rules.annotation.Priority;
+import org.jeasy.rules.annotation.Rule;
+import org.jeasy.rules.api.Facts;
 
 /**
  * Validate that an annotated rule object is well defined.
@@ -67,7 +70,7 @@ class RuleDefinitionValidator {
         Method conditionMethod = conditionMethods.get(0);
 
         if (!isConditionMethodWellDefined(conditionMethod)) {
-            throw new IllegalArgumentException(format("Condition method '%s' defined in rule '%s' must be public, may have parameters annotated with @Fact (and/or exactly one parameter of type Facts) and return boolean type.", conditionMethod, rule.getClass().getName()));
+            throw new IllegalArgumentException(format("Condition method '%s' defined in rule '%s' must be public, may have parameters annotated with @Fact (and/or exactly one parameter of type or extending Facts) and return boolean type.", conditionMethod, rule.getClass().getName()));
         }
     }
 
@@ -79,7 +82,7 @@ class RuleDefinitionValidator {
 
         for (Method actionMethod : actionMethods) {
             if (!isActionMethodWellDefined(actionMethod)) {
-                throw new IllegalArgumentException(format("Action method '%s' defined in rule '%s' must be public, must return void type and may have parameters annotated with @Fact (and/or exactly one parameter of type Facts).", actionMethod, rule.getClass().getName()));
+                throw new IllegalArgumentException(format("Action method '%s' defined in rule '%s' must be public, must return void type and may have parameters annotated with @Fact (and/or exactly one parameter of type or extending Facts).", actionMethod, rule.getClass().getName()));
             }
         }
     }
@@ -133,7 +136,7 @@ class RuleDefinitionValidator {
         }
         Class<?>[] parameterTypes = method.getParameterTypes();
         if(parameterTypes.length == 1 && notAnnotatedParameterCount == 1){
-            return parameterTypes[0].equals(Facts.class);
+            return Facts.class.isAssignableFrom(parameterTypes[0]);
         }
         return true;
     }

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithMultipleAnnotatedParametersAndOneParameterOfSubTypeFacts.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithMultipleAnnotatedParametersAndOneParameterOfSubTypeFacts.java
@@ -1,0 +1,43 @@
+/**
+ * The MIT License
+ *
+ *  Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package org.jeasy.rules.annotation;
+
+import org.jeasy.rules.api.Facts;
+
+@Rule
+public class AnnotatedRuleWithMultipleAnnotatedParametersAndOneParameterOfSubTypeFacts {
+
+    @Condition
+    public boolean when(@Fact("fact1") Object fact1, @Fact("fact2") Object fact2, SubFacts facts) {
+        return true;
+    }
+
+    @Action
+    public void then(@Fact("fact1") Object fact1, @Fact("fact2") Object fact2, SubFacts facts) {
+    }
+
+    public static class SubFacts extends Facts {
+
+    }
+}

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/RuleDefinitionValidatorTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/RuleDefinitionValidatorTest.java
@@ -133,6 +133,7 @@ public class RuleDefinitionValidatorTest {
     public void validAnnotationsShouldBeAccepted() {
         try {
             ruleDefinitionValidator.validateRuleDefinition(new AnnotatedRuleWithMultipleAnnotatedParametersAndOneParameterOfTypeFacts());
+            ruleDefinitionValidator.validateRuleDefinition(new AnnotatedRuleWithMultipleAnnotatedParametersAndOneParameterOfSubTypeFacts());
             ruleDefinitionValidator.validateRuleDefinition(new AnnotatedRuleWithActionMethodHavingOneArgumentOfTypeFacts());
         } catch (Throwable throwable) {
             Assertions.fail("Should not throw exception for valid rule definitions");


### PR DESCRIPTION
In some conditions, we need a custom _Facts_ and _RuleDefinitionValidation_ doesn't allow subclass of Facts as a parameter. In this case, we need to cast inside a **Rule** from **Facts** to **CustomFacts**, because parameter must be of type _Facts_

This PR resolve this.