### PR TITLE
[slf4j]: Use SLF4J

### DIFF
--- a/easy-rules-core/pom.xml
+++ b/easy-rules-core/pom.xml
@@ -51,6 +51,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/DefaultRuleListener.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/DefaultRuleListener.java
@@ -35,13 +35,13 @@ class DefaultRuleListener implements RuleListener {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultRuleListener.class);
 
     @Override
-    public boolean beforeEvaluate(Rule rule, Facts facts) {
+    public boolean beforeEvaluate(final Rule rule, final Facts facts) {
         return true;
     }
 
     @Override
-    public void afterEvaluate(Rule rule, Facts facts, boolean evaluationResult) {
-        String ruleName = rule.getName();
+    public void afterEvaluate(final Rule rule, final Facts facts, final boolean evaluationResult) {
+        final String ruleName = rule.getName();
         if (evaluationResult) {
             LOGGER.info("Rule ''{}'' triggered", ruleName);
         } else {
@@ -50,18 +50,19 @@ class DefaultRuleListener implements RuleListener {
     }
 
     @Override
-    public void beforeExecute(Rule rule, Facts facts) {
+    public void beforeExecute(final Rule rule, final Facts facts) {
 
     }
 
     @Override
-    public void onSuccess(Rule rule, Facts facts) {
+    public void onSuccess(final Rule rule, final Facts facts) {
         LOGGER.info("Rule ''{}'' performed successfully", rule.getName());
     }
 
     @Override
-    public void onFailure(Rule rule, Facts facts, Exception exception) {
-        LOGGER.info("Rule '{}' performed with error: {}",
-            rule.getName(), exception.getMessage());
+    public void onFailure(final Rule rule, final Facts facts, final Exception exception) {
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("Rule '" + rule.getName() + "' performed with error", exception);
+        }
     }
 }

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/DefaultRuleListener.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/DefaultRuleListener.java
@@ -27,12 +27,12 @@ import org.jeasy.rules.api.Facts;
 import org.jeasy.rules.api.Rule;
 import org.jeasy.rules.api.RuleListener;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class DefaultRuleListener implements RuleListener {
 
-    private static final Logger LOGGER = Logger.getLogger(DefaultRuleListener.class.getName());
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultRuleListener.class);
 
     @Override
     public boolean beforeEvaluate(Rule rule, Facts facts) {
@@ -43,9 +43,9 @@ class DefaultRuleListener implements RuleListener {
     public void afterEvaluate(Rule rule, Facts facts, boolean evaluationResult) {
         String ruleName = rule.getName();
         if (evaluationResult) {
-            LOGGER.log(Level.INFO, "Rule ''{0}'' triggered", ruleName);
+            LOGGER.info("Rule ''{}'' triggered", ruleName);
         } else {
-            LOGGER.log(Level.INFO, "Rule ''{0}'' has been evaluated to false, it has not been executed", ruleName);
+            LOGGER.info("Rule ''{}'' has been evaluated to false, it has not been executed", ruleName);
         }
     }
 
@@ -56,11 +56,12 @@ class DefaultRuleListener implements RuleListener {
 
     @Override
     public void onSuccess(Rule rule, Facts facts) {
-        LOGGER.log(Level.INFO, "Rule ''{0}'' performed successfully", rule.getName());
+        LOGGER.info("Rule ''{}'' performed successfully", rule.getName());
     }
 
     @Override
     public void onFailure(Rule rule, Facts facts, Exception exception) {
-        LOGGER.log(Level.SEVERE, String.format("Rule '%s' performed with error", rule.getName()), exception);
+        LOGGER.info("Rule '{}' performed with error: {}",
+            rule.getName(), exception.getMessage());
     }
 }

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/RulesEngineBuilder.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/RulesEngineBuilder.java
@@ -50,7 +50,7 @@ public class RulesEngineBuilder {
     }
 
     private RulesEngineBuilder() {
-        parameters = new RulesEngineParameters(false, false, false, false, RulesEngineParameters.DEFAULT_RULE_PRIORITY_THRESHOLD, false);
+        parameters = new RulesEngineParameters(false, false, false, false, RulesEngineParameters.DEFAULT_RULE_PRIORITY_THRESHOLD);
         ruleListeners = new ArrayList<>();
     }
 
@@ -117,17 +117,6 @@ public class RulesEngineBuilder {
      */
     public RulesEngineBuilder withRuleListener(final RuleListener ruleListener) {
         this.ruleListeners.add(ruleListener);
-        return this;
-    }
-
-    /**
-     * Set silent mode to mute all loggers.
-     *
-     * @param silentMode to set
-     * @return the rules engine builder
-     */
-    public RulesEngineBuilder withSilentMode(final boolean silentMode) {
-        parameters.setSilentMode(silentMode);
         return this;
     }
 

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/RulesEngineBuilder.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/RulesEngineBuilder.java
@@ -36,9 +36,9 @@ import java.util.List;
  */
 public class RulesEngineBuilder {
 
-    private RulesEngineParameters parameters;
+    private final RulesEngineParameters parameters;
 
-    private List<RuleListener> ruleListeners;
+    private final List<RuleListener> ruleListeners;
 
     /**
      * Create a new rules engine builder.
@@ -117,6 +117,15 @@ public class RulesEngineBuilder {
      */
     public RulesEngineBuilder withRuleListener(final RuleListener ruleListener) {
         this.ruleListeners.add(ruleListener);
+        return this;
+    }
+
+    /**
+     * @deprecated Silent mode is now log implementation config. Now it uses slf4j facade
+     * <strong>This will be removed in v3.2</strong>
+     */
+    @Deprecated
+    public RulesEngineBuilder withSilentMode(final boolean silentMode) {
         return this;
     }
 

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/RulesEngineParameters.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/RulesEngineParameters.java
@@ -33,7 +33,7 @@ public class RulesEngineParameters {
     /**
      * Default rule priority threshold.
      */
-    public static int DEFAULT_RULE_PRIORITY_THRESHOLD = Integer.MAX_VALUE;
+    public static final int DEFAULT_RULE_PRIORITY_THRESHOLD = Integer.MAX_VALUE;
     
     /**
      * Parameter to skip next applicable rules when a rule is applied.
@@ -73,10 +73,20 @@ public class RulesEngineParameters {
      * <strong>This constructor will be removed in v3.2</strong>
      */
     @Deprecated
-    public RulesEngineParameters(boolean skipOnFirstAppliedRule, boolean skipOnFirstFailedRule, int priorityThreshold) {
+    public RulesEngineParameters(final boolean skipOnFirstAppliedRule, final boolean skipOnFirstFailedRule, final int priorityThreshold, final boolean silentMode) {
         this.skipOnFirstAppliedRule = skipOnFirstAppliedRule;
         this.skipOnFirstFailedRule = skipOnFirstFailedRule;
         this.priorityThreshold = priorityThreshold;
+    }
+
+    /**
+     * Create a new {@link RulesEngineParameters}.
+     * @deprecated Use {@link RulesEngineParameters#RulesEngineParameters(boolean, boolean, boolean, boolean, int)} instead.
+     * <strong>This constructor will be removed in v3.2</strong>
+     */
+    @Deprecated
+    public RulesEngineParameters(final boolean skipOnFirstAppliedRule, final boolean skipOnFirstFailedRule, final boolean skipOnFirstNonTriggeredRule, final boolean skipOnMissingFact, final int priorityThreshold, final boolean silentMode) {
+        this(skipOnFirstAppliedRule, skipOnFirstFailedRule, skipOnFirstNonTriggeredRule, skipOnMissingFact, priorityThreshold);
     }
 
     /**
@@ -88,7 +98,7 @@ public class RulesEngineParameters {
      * @param skipOnMissingFact parameter to skip a rule if a declared fact is missing.
      * @param priorityThreshold threshold after which rules should be skipped.
      */
-    public RulesEngineParameters(boolean skipOnFirstAppliedRule, boolean skipOnFirstFailedRule, boolean skipOnFirstNonTriggeredRule, boolean skipOnMissingFact, int priorityThreshold) {
+    public RulesEngineParameters(final boolean skipOnFirstAppliedRule, final boolean skipOnFirstFailedRule, final boolean skipOnFirstNonTriggeredRule, final boolean skipOnMissingFact, final int priorityThreshold) {
         this.skipOnFirstAppliedRule = skipOnFirstAppliedRule;
         this.skipOnFirstFailedRule = skipOnFirstFailedRule;
         this.skipOnFirstNonTriggeredRule = skipOnFirstNonTriggeredRule;
@@ -100,7 +110,25 @@ public class RulesEngineParameters {
         return priorityThreshold;
     }
 
-    public void setPriorityThreshold(int priorityThreshold) {
+    /**
+     * @deprecated Silent mode is now log implementation config. Now it uses slf4j facade
+     * <strong>This will be removed in v3.2</strong>
+     */
+    @Deprecated
+    public boolean isSilentMode() {
+        return false;
+    }
+
+    /**
+     * @deprecated Silent mode is now log implementation config. Now it uses slf4j facade
+     * <strong>This will be removed in v3.2</strong>
+     */
+    @Deprecated
+    public void setSilentMode(final boolean silentMode) {
+
+    }
+
+    public void setPriorityThreshold(final int priorityThreshold) {
         this.priorityThreshold = priorityThreshold;
     }
 
@@ -108,7 +136,7 @@ public class RulesEngineParameters {
         return skipOnFirstAppliedRule;
     }
 
-    public void setSkipOnFirstAppliedRule(boolean skipOnFirstAppliedRule) {
+    public void setSkipOnFirstAppliedRule(final boolean skipOnFirstAppliedRule) {
         this.skipOnFirstAppliedRule = skipOnFirstAppliedRule;
     }
 
@@ -116,7 +144,7 @@ public class RulesEngineParameters {
         return skipOnFirstNonTriggeredRule;
     }
 
-    public void setSkipOnFirstNonTriggeredRule(boolean skipOnFirstNonTriggeredRule) {
+    public void setSkipOnFirstNonTriggeredRule(final boolean skipOnFirstNonTriggeredRule) {
         this.skipOnFirstNonTriggeredRule = skipOnFirstNonTriggeredRule;
     }
 
@@ -124,7 +152,7 @@ public class RulesEngineParameters {
         return skipOnFirstFailedRule;
     }
 
-    public void setSkipOnFirstFailedRule(boolean skipOnFirstFailedRule) {
+    public void setSkipOnFirstFailedRule(final boolean skipOnFirstFailedRule) {
         this.skipOnFirstFailedRule = skipOnFirstFailedRule;
     }
 
@@ -132,7 +160,7 @@ public class RulesEngineParameters {
         return skipOnMissingFact;
     }
 
-    public void setSkipOnMissingFact(boolean skipOnMissingFact) {
+    public void setSkipOnMissingFact(final boolean skipOnMissingFact) {
         this.skipOnMissingFact = skipOnMissingFact;
     }
 }

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/RulesEngineParameters.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/RulesEngineParameters.java
@@ -61,11 +61,6 @@ public class RulesEngineParameters {
     private int priorityThreshold;
 
     /**
-     * Parameter to mute loggers.
-     */
-    private boolean silentMode;
-
-    /**
      * Create a new {@link RulesEngineParameters} with default values.
      */
     public RulesEngineParameters() {
@@ -74,15 +69,14 @@ public class RulesEngineParameters {
 
     /**
      * Create a new {@link RulesEngineParameters}
-     * @deprecated Use {@link RulesEngineParameters#RulesEngineParameters(boolean, boolean, boolean, boolean, int, boolean)} instead.
+     * @deprecated Use {@link RulesEngineParameters#RulesEngineParameters(boolean, boolean, boolean, boolean, int)} instead.
      * <strong>This constructor will be removed in v3.2</strong>
      */
     @Deprecated
-    public RulesEngineParameters(boolean skipOnFirstAppliedRule, boolean skipOnFirstFailedRule, int priorityThreshold, boolean silentMode) {
+    public RulesEngineParameters(boolean skipOnFirstAppliedRule, boolean skipOnFirstFailedRule, int priorityThreshold) {
         this.skipOnFirstAppliedRule = skipOnFirstAppliedRule;
         this.skipOnFirstFailedRule = skipOnFirstFailedRule;
         this.priorityThreshold = priorityThreshold;
-        this.silentMode = silentMode;
     }
 
     /**
@@ -93,15 +87,13 @@ public class RulesEngineParameters {
      * @param skipOnFirstNonTriggeredRule parameter to skip next applicable rules on first non triggered rule.
      * @param skipOnMissingFact parameter to skip a rule if a declared fact is missing.
      * @param priorityThreshold threshold after which rules should be skipped.
-     * @param silentMode parameter to mute all loggers.
      */
-    public RulesEngineParameters(boolean skipOnFirstAppliedRule, boolean skipOnFirstFailedRule, boolean skipOnFirstNonTriggeredRule, boolean skipOnMissingFact, int priorityThreshold, boolean silentMode) {
+    public RulesEngineParameters(boolean skipOnFirstAppliedRule, boolean skipOnFirstFailedRule, boolean skipOnFirstNonTriggeredRule, boolean skipOnMissingFact, int priorityThreshold) {
         this.skipOnFirstAppliedRule = skipOnFirstAppliedRule;
         this.skipOnFirstFailedRule = skipOnFirstFailedRule;
         this.skipOnFirstNonTriggeredRule = skipOnFirstNonTriggeredRule;
         this.skipOnMissingFact = skipOnMissingFact;
         this.priorityThreshold = priorityThreshold;
-        this.silentMode = silentMode;
     }
 
     public int getPriorityThreshold() {
@@ -110,14 +102,6 @@ public class RulesEngineParameters {
 
     public void setPriorityThreshold(int priorityThreshold) {
         this.priorityThreshold = priorityThreshold;
-    }
-
-    public boolean isSilentMode() {
-        return silentMode;
-    }
-
-    public void setSilentMode(boolean silentMode) {
-        this.silentMode = silentMode;
     }
 
     public boolean isSkipOnFirstAppliedRule() {

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/Utils.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/Utils.java
@@ -23,53 +23,12 @@
  */
 package org.jeasy.rules.core;
 
-import java.io.IOException;
 import java.lang.annotation.Annotation;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.logging.Handler;
-import java.util.logging.Level;
-import java.util.logging.LogManager;
-import java.util.logging.Logger;
-
-import static java.util.Arrays.asList;
 
 final class Utils {
 
-    private static final Logger LOGGER = Logger.getLogger(Utils.class.getName());
-
-    static {
-        try {
-            if (System.getProperty("java.util.logging.config.file") == null &&
-                    System.getProperty("java.util.logging.config.class") == null) {
-                LogManager.getLogManager().readConfiguration(Utils.class.getResourceAsStream("/logging.properties"));
-            }
-        } catch (IOException e) {
-            LOGGER.log(Level.WARNING, "Unable to load logging configuration file", e);
-        }
-    }
-
     private Utils() {
 
-    }
-
-    static void muteLoggers() {
-        Enumeration<String> loggerNames = LogManager.getLogManager().getLoggerNames();
-        while (loggerNames.hasMoreElements()) {
-            String loggerName = loggerNames.nextElement();
-            if (loggerName.startsWith("org.jeasy.rules")) {
-                muteLogger(loggerName);
-            }
-        }
-    }
-
-    private static void muteLogger(final String logger) {
-        Logger.getLogger(logger).setUseParentHandlers(false);
-        Handler[] handlers = Logger.getLogger(logger).getHandlers();
-        for (Handler handler : handlers) {
-            Logger.getLogger(logger).removeHandler(handler);
-        }
     }
 
     static <A extends Annotation> A findAnnotation(final Class<A> targetAnnotation, final Class<?> annotatedType) {

--- a/easy-rules-core/src/main/resources/logging.properties
+++ b/easy-rules-core/src/main/resources/logging.properties
@@ -1,4 +1,0 @@
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=INFO
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
-java.util.logging.SimpleFormatter.format=%1$tF %tT.%1$tL %4$s [%2$s] - %5$s %6$s%n

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/DefaultRulesEngineTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/DefaultRulesEngineTest.java
@@ -23,22 +23,24 @@
  */
 package org.jeasy.rules.core;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
 import org.assertj.core.api.Assertions;
 import org.jeasy.rules.annotation.Action;
 import org.jeasy.rules.annotation.Condition;
 import org.jeasy.rules.annotation.Priority;
-import org.jeasy.rules.api.Facts;
 import org.jeasy.rules.api.RuleListener;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.*;
-
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import org.mockito.InOrder;
+import org.mockito.Mock;
 
 /**
  * Test class for {@link DefaultRulesEngine}.
@@ -56,7 +58,6 @@ public class DefaultRulesEngineTest extends AbstractTest {
     public void setup() throws Exception {
         super.setup();
         when(rule1.getName()).thenReturn("r");
-        when(rule1.getDescription()).thenReturn("d");
         when(rule1.getPriority()).thenReturn(1);
         annotatedRule = new AnnotatedRule();
     }

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/RulesEngineBuilderTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/RulesEngineBuilderTest.java
@@ -23,14 +23,14 @@
  */
 package org.jeasy.rules.core;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.jeasy.rules.api.RuleListener;
 import org.jeasy.rules.api.RulesEngine;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RulesEngineBuilderTest {
@@ -64,7 +64,6 @@ public class RulesEngineBuilderTest {
         RulesEngine rulesEngine = RulesEngineBuilder.aNewRulesEngine()
                 .withRuleListener(ruleListener)
                 .withRulePriorityThreshold(expectedThreshold)
-                .withSilentMode(true)
                 .withSkipOnFirstNonTriggeredRule(true)
                 .withSkipOnFirstAppliedRule(true)
                 .withSkipOnFirstFailedRule(true)
@@ -74,7 +73,6 @@ public class RulesEngineBuilderTest {
         assertThat(rulesEngine).isNotNull();
         RulesEngineParameters parameters = rulesEngine.getParameters();
         assertThat(parameters.getPriorityThreshold()).isEqualTo(expectedThreshold);
-        assertThat(parameters.isSilentMode()).isTrue();
         assertThat(parameters.isSkipOnFirstAppliedRule()).isTrue();
         assertThat(parameters.isSkipOnFirstFailedRule()).isTrue();
         assertThat(parameters.isSkipOnFirstNonTriggeredRule()).isTrue();

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/fizzbuzz/FizzBuzzWithEasyRules.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/fizzbuzz/FizzBuzzWithEasyRules.java
@@ -23,18 +23,17 @@
  */
 package org.jeasy.rules.tutorials.fizzbuzz;
 
+import static org.jeasy.rules.core.RulesEngineBuilder.aNewRulesEngine;
+
 import org.jeasy.rules.api.Facts;
 import org.jeasy.rules.api.Rules;
 import org.jeasy.rules.api.RulesEngine;
-
-import static org.jeasy.rules.core.RulesEngineBuilder.aNewRulesEngine;
 
 public class FizzBuzzWithEasyRules {
     public static void main(String[] args) {
         // create rules engine
         RulesEngine fizzBuzzEngine = aNewRulesEngine()
                 .withSkipOnFirstAppliedRule(true)
-                .withSilentMode(true)
                 .build();
 
         // create rules

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/web/SuspiciousRequestFilter.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/web/SuspiciousRequestFilter.java
@@ -23,15 +23,19 @@
  */
 package org.jeasy.rules.tutorials.web;
 
+import static org.jeasy.rules.core.RulesEngineBuilder.aNewRulesEngine;
+
+import java.io.IOException;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
 import org.jeasy.rules.api.Facts;
 import org.jeasy.rules.api.Rules;
 import org.jeasy.rules.api.RulesEngine;
-
-import javax.servlet.*;
-import javax.servlet.annotation.WebFilter;
-import java.io.IOException;
-
-import static org.jeasy.rules.core.RulesEngineBuilder.aNewRulesEngine;
 
 @WebFilter("/*")
 public class SuspiciousRequestFilter implements Filter {
@@ -41,7 +45,7 @@ public class SuspiciousRequestFilter implements Filter {
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
-        rulesEngine = aNewRulesEngine().withSilentMode(true).build();
+        rulesEngine = aNewRulesEngine().build();
         rules = new Rules();
         rules.register(new SuspiciousRequestRule());
     }

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.25</version>
+            </dependency>
+
+            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <junit.version>4.12</junit.version>
         <assertj.version>2.6.0</assertj.version>
         <mockito.version>2.7.1</mockito.version>
+        <slf4j-api.version>1.7.25</slf4j-api.version>
         <maven-cobertura-plugin.version>2.7</maven-cobertura-plugin.version>
         <maven-coveralls-plugin.version>4.3.0</maven-coveralls-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
@@ -87,7 +88,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.25</version>
+                <version>${slf4j-api.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Use SLF4J instead of java.util.logging #113

No more needed **silentMode** option. Logs have INFO level. If you do not want to log, simply configure your logging engine for not log **org.jeasy.rules** package at INFO level.