### PR TITLE
Create rules from java.io.Reader

### DIFF
--- a/easy-rules-mvel/src/main/java/org/jeasy/rules/mvel/MVELRuleDefinitionReader.java
+++ b/easy-rules-mvel/src/main/java/org/jeasy/rules/mvel/MVELRuleDefinitionReader.java
@@ -57,5 +57,4 @@ class MVELRuleDefinitionReader {
         ruleDefinition.setActions((List<String>) map.get("actions"));
         return ruleDefinition;
     }
-
 }

--- a/easy-rules-mvel/src/main/java/org/jeasy/rules/mvel/MVELRuleDefinitionReader.java
+++ b/easy-rules-mvel/src/main/java/org/jeasy/rules/mvel/MVELRuleDefinitionReader.java
@@ -42,6 +42,12 @@ class MVELRuleDefinitionReader {
         return createRuleDefinitionFrom(map);
     }
 
+    MVELRuleDefinition read(String descriptor) throws NullPointerException {
+        Object object = yaml.load(descriptor);
+        Map<String, Object> map = (Map<String, Object>) object;
+        return createRuleDefinitionFrom(map);
+    }
+
     private static MVELRuleDefinition createRuleDefinitionFrom(Map<String, Object> map) {
         MVELRuleDefinition ruleDefinition = new MVELRuleDefinition();
         ruleDefinition.setName((String) map.get("name"));

--- a/easy-rules-mvel/src/main/java/org/jeasy/rules/mvel/MVELRuleFactory.java
+++ b/easy-rules-mvel/src/main/java/org/jeasy/rules/mvel/MVELRuleFactory.java
@@ -25,6 +25,8 @@ package org.jeasy.rules.mvel;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.Reader;
 
 /**
  * Factory to create {@link MVELRule} instances.
@@ -47,4 +49,23 @@ public class MVELRuleFactory {
         return ruleDefinition.create();
     }
 
+    /**
+     * Create a new {@link MVELRule} from a Reader.
+     *
+     * @param ruleDescriptorReader as a Reader
+     * @return a new rule
+     * @throws IOException if the I/O operation failed
+     */
+    public static MVELRule createRuleFrom(Reader ruleDescriptorReader) throws IOException {
+        StringBuilder ruleDescriptor = new StringBuilder();
+
+        int charValue;
+        while ((charValue = ruleDescriptorReader.read()) != -1) {
+            ruleDescriptor.append((char) charValue);
+        }
+        ruleDescriptorReader.close();
+
+        MVELRuleDefinition ruleDefinition = reader.read(ruleDescriptor.toString());
+        return ruleDefinition.create();
+    }
 }

--- a/easy-rules-mvel/src/test/java/org/jeasy/rules/mvel/MVELRuleDefinitionReaderTest.java
+++ b/easy-rules-mvel/src/test/java/org/jeasy/rules/mvel/MVELRuleDefinitionReaderTest.java
@@ -26,6 +26,8 @@ package org.jeasy.rules.mvel;
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -50,5 +52,23 @@ public class MVELRuleDefinitionReaderTest {
         assertThat(adultRuleDefinition.getCondition()).isEqualTo("person.age > 18");
         assertThat(adultRuleDefinition.getActions()).isEqualTo(Collections.singletonList("person.setAdult(true);"));
     }
+
+    @Test
+    public void testRuleDefinitionReadingFromString() throws Exception {
+        // given
+        String adultRuleDescriptor = new String(Files.readAllBytes(Paths.get("src/test/resources/adult-rule.yml")));
+
+        // when
+        MVELRuleDefinition adultRuleDefinition = ruleDefinitionReader.read(adultRuleDescriptor);
+
+        // then
+        assertThat(adultRuleDefinition).isNotNull();
+        assertThat(adultRuleDefinition.getName()).isEqualTo("adult rule");
+        assertThat(adultRuleDefinition.getDescription()).isEqualTo("when age is greater then 18, then mark as adult");
+        assertThat(adultRuleDefinition.getPriority()).isEqualTo(1);
+        assertThat(adultRuleDefinition.getCondition()).isEqualTo("person.age > 18");
+        assertThat(adultRuleDefinition.getActions()).isEqualTo(Collections.singletonList("person.setAdult(true);"));
+    }
+
 
 }

--- a/easy-rules-mvel/src/test/java/org/jeasy/rules/mvel/MVELRuleDefinitionReaderTest.java
+++ b/easy-rules-mvel/src/test/java/org/jeasy/rules/mvel/MVELRuleDefinitionReaderTest.java
@@ -69,6 +69,4 @@ public class MVELRuleDefinitionReaderTest {
         assertThat(adultRuleDefinition.getCondition()).isEqualTo("person.age > 18");
         assertThat(adultRuleDefinition.getActions()).isEqualTo(Collections.singletonList("person.setAdult(true);"));
     }
-
-
 }

--- a/easy-rules-mvel/src/test/java/org/jeasy/rules/mvel/MVELRuleFactoryTest.java
+++ b/easy-rules-mvel/src/test/java/org/jeasy/rules/mvel/MVELRuleFactoryTest.java
@@ -26,6 +26,11 @@ package org.jeasy.rules.mvel;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.FileReader;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -38,6 +43,34 @@ public class MVELRuleFactoryTest {
 
         // when
         MVELRule adultRule = MVELRuleFactory.createRuleFrom(adultRuleDescriptor);
+
+        // then
+        assertThat(adultRule.getName()).isEqualTo("adult rule");
+        assertThat(adultRule.getDescription()).isEqualTo("when age is greater then 18, then mark as adult");
+        assertThat(adultRule.getPriority()).isEqualTo(1);
+    }
+
+    @Test
+    public void testRuleCreationFromFileReader() throws Exception{
+        // given
+        Reader adultRuleDescriptorAsReader = new FileReader("src/test/resources/adult-rule.yml");
+
+        // when
+        MVELRule adultRule = MVELRuleFactory.createRuleFrom(adultRuleDescriptorAsReader);
+
+        // then
+        assertThat(adultRule.getName()).isEqualTo("adult rule");
+        assertThat(adultRule.getDescription()).isEqualTo("when age is greater then 18, then mark as adult");
+        assertThat(adultRule.getPriority()).isEqualTo(1);
+    }
+
+    @Test
+    public void testRuleCreationFromStringReader() throws Exception{
+        // given
+        Reader adultRuleDescriptorAsReader = new StringReader(new String(Files.readAllBytes(Paths.get("src/test/resources/adult-rule.yml"))));
+
+        // when
+        MVELRule adultRule = MVELRuleFactory.createRuleFrom(adultRuleDescriptorAsReader);
 
         // then
         assertThat(adultRule.getName()).isEqualTo("adult rule");


### PR DESCRIPTION
This PR resolves #133 by enabling users to create rules from a java.io.Reader object (be it a FileReader or StringReader).

