### PR TITLE
Add test to cover unregister non existing rule

### DIFF
--- a/easy-rules-core/src/test/java/org/jeasy/rules/api/RulesTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/api/RulesTest.java
@@ -79,6 +79,18 @@ public class RulesTest {
 
         assertThat(rules).hasSize(1).containsExactly(r1);
     }
+    
+    @Test
+    public void unregisterByNameNonExistingRule() throws Exception {
+        Rule r1 = new BasicRule("rule1");
+        Set<Rule> ruleSet = new HashSet<>();
+        ruleSet.add(r1);
+        
+        rules = new Rules(ruleSet);
+        rules.unregister("rule2");
+
+        assertThat(rules).hasSize(1).containsExactly(r1);
+    }
 
     @Test
     public void isEmpty() throws Exception {


### PR DESCRIPTION
I saw the method unregister isn't fully covered because there isn't a test to prove what happens when you delete a rule.

The RuleSet shoulld remain equal and no exception should be thrown