### PR TITLE
toString() in original object and toString in proxy are different 

### DIFF
--- a/easy-rules-core/src/test/java/org/jeasy/rules/api/RulesTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/api/RulesTest.java
@@ -79,6 +79,18 @@ public class RulesTest {
 
         assertThat(rules).hasSize(1).containsExactly(r1);
     }
+    
+    @Test
+    public void unregisterByNameNonExistingRule() throws Exception {
+        Rule r1 = new BasicRule("rule1");
+        Set<Rule> ruleSet = new HashSet<>();
+        ruleSet.add(r1);
+        
+        rules = new Rules(ruleSet);
+        rules.unregister("rule2");
+
+        assertThat(rules).hasSize(1).containsExactly(r1);
+    }
 
     @Test
     public void isEmpty() throws Exception {

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/RuleProxyTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/RuleProxyTest.java
@@ -117,7 +117,8 @@ public class RuleProxyTest {
         assertNotEquals(proxy2, null);
         assertNotEquals(proxy3, null);
     }
-
+    
+    
     @Test
     public void invokeHashCode() {
 
@@ -139,6 +140,20 @@ public class RuleProxyTest {
         assertNotEquals(rule, proxy1);
         assertNotEquals(rule.hashCode(), proxy1.hashCode());
     }
+    
+    @Test
+    public void invokeToString() {
+
+        Object rule = new DummyRule();
+        Rule proxy1 = RuleProxy.asRule(rule);
+        Rule proxy2 = RuleProxy.asRule(proxy1);
+        
+        assertEquals(proxy1.toString(), proxy1.toString());
+                
+        assertEquals(proxy1.toString(), proxy2.toString());
+        
+        assertEquals(rule.toString(), proxy1.toString());
+    }
 
     @org.jeasy.rules.annotation.Rule
     class DummyRule {
@@ -147,6 +162,13 @@ public class RuleProxyTest {
 
         @Action
         public void then() { }
+        
+        @Override
+        public String toString() {
+        	return "I am a Dummy rule";
+        }
+        
+        
     }
 }
 


### PR DESCRIPTION
In Proxy object the toString() method returns something different than original object does.
