### PR TITLE
Removed the listeners added by default to DefaultRulesEngine

### DIFF
--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/DefaultRuleListener.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/DefaultRuleListener.java
@@ -30,7 +30,7 @@ import org.jeasy.rules.api.RuleListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class DefaultRuleListener implements RuleListener {
+public final class DefaultRuleListener implements RuleListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultRuleListener.class);
 

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/DefaultRulesEngine.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/DefaultRulesEngine.java
@@ -68,9 +68,7 @@ public final class DefaultRulesEngine implements RulesEngine {
     public DefaultRulesEngine(final RulesEngineParameters parameters) {
         this.parameters = parameters;
         this.ruleListeners = new ArrayList<>();
-        this.ruleListeners.add(new DefaultRuleListener());
         this.rulesEngineListeners = new ArrayList<>();
-        this.rulesEngineListeners.add(new DefaultRulesEngineListener(parameters));
     }
 
     @Override

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/DefaultRulesEngineListener.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/DefaultRulesEngineListener.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
-class DefaultRulesEngineListener implements RulesEngineListener {
+public class DefaultRulesEngineListener implements RulesEngineListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultRulesEngineListener.class);
 


### PR DESCRIPTION
Hi,
the listeners added by default are to opinionated in my mind (e.g. they use a predefined logger and log on info).
I removed them and made the implementation of the listeners public final, so everyone can added them when needed