### PR TITLE
Fix to issue #158

### DIFF
--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/RulesEngine.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/RulesEngine.java
@@ -40,7 +40,7 @@ public interface RulesEngine {
      *
      * @return The rules engine parameters
      */
-    RulesEngineParameters getParameters();
+    RulesEngineParameters getParameters() throws CloneNotSupportedException;
 
     /**
      * Return the list of registered rule listeners.

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/DefaultRulesEngine.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/DefaultRulesEngine.java
@@ -74,7 +74,7 @@ public final class DefaultRulesEngine implements RulesEngine {
     }
     /*makes and returns a shallow copy of the parameters object*/
     @Override
-    public RulesEngineParameters getParameters() {
+    public RulesEngineParameters getParameters() throws CloneNotSupportedException {
         RulesEngineParameters copy = (RulesEngineParameters) parameters.clone();
         return copy;
     }

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/DefaultRulesEngine.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/DefaultRulesEngine.java
@@ -72,10 +72,11 @@ public final class DefaultRulesEngine implements RulesEngine {
         this.rulesEngineListeners = new ArrayList<>();
         this.rulesEngineListeners.add(new DefaultRulesEngineListener(parameters));
     }
-
+    /*makes and returns a shallow copy of the parameters object*/
     @Override
     public RulesEngineParameters getParameters() {
-        return parameters;
+        RulesEngineParameters copy = (RulesEngineParameters) parameters.clone();
+        return copy;
     }
 
     @Override

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/RulesEngineParameters.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/RulesEngineParameters.java
@@ -33,7 +33,7 @@ package org.jeasy.rules.core;
  *
  * @author Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  */
-public class RulesEngineParameters {
+public class RulesEngineParameters implements Cloneable {
 
     /**
      * Default rule priority threshold.
@@ -143,4 +143,10 @@ public class RulesEngineParameters {
                 ", priorityThreshold = " + priorityThreshold +
                 " }";
     }
+    /*function for getting a copy of this object*/
+    @Override
+        public Object clone() throws CloneNotSupportedException {
+	    return super.clone();
+	}
+    
 }


### PR DESCRIPTION
A simple solution attempt: Modified RulesEngine#getParameters to use the clone() method and return a copy of the parameters object. I'm not sure if a shallow copy is enough, but perhaps others can build on this.