### PR TITLE
updated readme not to use deprecated createRuleFrom()

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ actions:
 ```
 
 ```java
-Rule weatherRule = MVELRuleFactory.createRuleFrom(new File("weather-rule.yml"));
+Rule weatherRule = MVELRuleFactory.createRuleFrom(new FileReader("weather-rule.yml"));
 ```
 
 ### 2. Then, fire it!


### PR DESCRIPTION
The README was
Rule weatherRule = MVELRuleFactory.createRuleFrom(new File("weather-rule.yml"));

But this is deprecated in the latest version or before (v3.2.0), hence updated to use the overloaded method.