### PR TITLE
Update UnitRuleGroupTest.java

### DIFF
--- a/easy-rules-support/src/test/java/org/jeasy/rules/support/UnitRuleGroupTest.java
+++ b/easy-rules-support/src/test/java/org/jeasy/rules/support/UnitRuleGroupTest.java
@@ -89,14 +89,16 @@ public class UnitRuleGroupTest {
         verify(rule2).execute(facts);
     }
 
+    @Test
     public void compositeRuleMustNotBeExecutedIfAComposingRuleEvaluatesToFalse() throws Exception {
         // Given
-        when(rule2.evaluate(facts)).thenReturn(false);
+        unitRuleGroup = new UnitRuleGroup();
         unitRuleGroup.addRule(rule1);
         unitRuleGroup.addRule(rule2);
         rules.register(unitRuleGroup);
 
         // When
+        when(rule2.evaluate(facts)).thenReturn(false);
         rulesEngine.fire(rules, facts);
 
         // Then


### PR DESCRIPTION
add @Test on UnitRuleGroupTest#compositeRuleMustNotBeExecutedIfAComposingRuleEvaluatesToFalse Method.
new a unitRuleGroup Object in the test case to avoid NPE .