### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>${maven-javadoc-plugin.version}</version>
                     <configuration>
-                        <additionalparam>-Xdoclint:none</additionalparam>
+                        <doclint>none</doclint>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
on my idea (java8),the parent pom.xml prompt `Element additionalparam is not allowed here.`
according the reference :  [https://maven.apache.org/plugins/maven-javadoc-plugin/javadoc-mojo.html#doclint](url)
if we want to turn off doclint , we should use `<doclint>none</doclint>`