### PR TITLE
Added an executable rule group with its own action

### DIFF
--- a/easy-rules-support/src/main/java/org/jeasy/rules/support/ExecutableRuleGroup.java
+++ b/easy-rules-support/src/main/java/org/jeasy/rules/support/ExecutableRuleGroup.java
@@ -1,0 +1,109 @@
+/**
+ * The MIT License
+ *
+ *  Copyright (c) 2019, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package org.jeasy.rules.support;
+
+import org.jeasy.rules.api.Action;
+import org.jeasy.rules.api.Facts;
+import org.jeasy.rules.api.Rule;
+
+/**
+ * An executable rule group is a composite rule that has it's own action defined. When all rules
+ * in the rule group are true, the actions of the rules are fired, and then the group's own.
+ *
+ * @author Frank Bosman (fbushman at gmail dot com)
+ */
+public class ExecutableRuleGroup extends CompositeRule {
+
+    protected final Action action;
+
+    /**
+     * Create an actionable rule group.
+     *
+     * @param action of the executable rule group
+     */
+    public ExecutableRuleGroup(final Action action) {
+        super();
+        this.action = action;
+    }
+
+    /**
+     * Create an actionable rule group.
+     *
+     * @param name of the executable rule group
+     * @param action of the executable rule group
+     */
+    public ExecutableRuleGroup(final String name, final Action action) {
+        super(name);
+        this.action = action;
+    }
+
+    /**
+     * Create an actionable rule group.
+     *
+     * @param name of the executable rule group
+     * @param description of the executable rule group
+     * @param action of the executable rule group
+     */
+    public ExecutableRuleGroup(final String name, final String description, final Action action) {
+        super(name, description);
+        this.action = action;
+    }
+
+    /**
+     * Create an actionable rule group.
+     *
+     * @param name of the executable rule group
+     * @param description of the executable rule group
+     * @param priority of the executable rule group
+     * @param action of the executable rule group
+     */
+    public ExecutableRuleGroup(final String name, final String description, final int priority, final Action action) {
+        super(name, description, priority);
+        this.action = action;
+    }
+
+    @Override
+    public boolean evaluate(Facts facts) {
+        // No rules, group is false
+        if (rules.isEmpty()) {
+            return false;
+        }
+        for (Rule rule : rules) {
+            // Any rule is false, group is false
+            if (!rule.evaluate(facts)) {
+                return false;
+            }
+        }
+        // Only return true when all rules where true
+        return true;
+    }
+
+    @Override
+    public void execute(Facts facts) throws Exception {
+        for (Rule rule : rules) {
+            rule.execute(facts);
+        }
+        this.action.execute(facts);
+    }
+}

--- a/easy-rules-support/src/test/java/org/jeasy/rules/support/ExecutableRuleGroupTest.java
+++ b/easy-rules-support/src/test/java/org/jeasy/rules/support/ExecutableRuleGroupTest.java
@@ -1,0 +1,148 @@
+/**
+ * The MIT License
+ *
+ *  Copyright (c) 2019, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package org.jeasy.rules.support;
+
+import org.jeasy.rules.api.Action;
+import org.jeasy.rules.api.Facts;
+import org.jeasy.rules.api.Rule;
+import org.jeasy.rules.api.Rules;
+import org.jeasy.rules.core.DefaultRulesEngine;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ExecutableRuleGroupTest {
+
+    @Mock
+    private Rule ruleTrue, ruleFalse, ruleTrueToo;
+
+    private Facts facts = new Facts();
+    private Rules rules = new Rules();
+
+    private DefaultRulesEngine rulesEngine = new DefaultRulesEngine();
+
+    private ExecutableRuleGroup executableRuleGroup;
+
+    @Before
+    public void before() {
+        when(ruleTrue.evaluate(facts)).thenReturn(true);
+        when(ruleTrueToo.evaluate(facts)).thenReturn(true);
+        when(ruleFalse.evaluate(facts)).thenReturn(false);
+        when(ruleFalse.compareTo(ruleTrue)).thenReturn(1);
+        when(ruleTrueToo.compareTo(ruleTrue)).thenReturn(1);
+    }
+
+    @Test
+    public void whenOneRuleIsTrue_thenActionableRuleGroupShouldEvaluateToFalse() {
+        // given
+        executableRuleGroup = new ExecutableRuleGroup(new Action() {
+            @Override
+            public void execute(Facts facts) {
+                fail("When one rule is true, then ActionableRuleGroup should not execute.");
+            }
+        });
+        executableRuleGroup.addRule(ruleTrue);
+        executableRuleGroup.addRule(ruleFalse);
+
+        // when
+        boolean evaluationResult = executableRuleGroup.evaluate(facts);
+
+        // then
+        assertThat(evaluationResult).isFalse();
+    }
+
+    @Test
+    public void whenOneRuleIsTrue_thenActionableRuleGroupShouldNotExecute() {
+        // given
+        executableRuleGroup = new ExecutableRuleGroup(new Action() {
+            @Override
+            public void execute(Facts facts) {
+                fail("When one rule is true, then ActionableRuleGroup should not execute.");
+            }
+        });
+        executableRuleGroup.addRule(ruleTrue);
+        executableRuleGroup.addRule(ruleFalse);
+        rules.register(executableRuleGroup);
+
+        // when
+        rulesEngine.fire(rules, facts);
+
+        // then
+        // success!
+    }
+
+    @Test
+    public void whenBothRulesAreTrue_thenActionableRuleGroupShouldExecute() {
+        // given
+        final AtomicBoolean evaluateExecution = new AtomicBoolean(false);
+        executableRuleGroup = new ExecutableRuleGroup(new Action() {
+            @Override
+            public void execute(Facts facts) {
+                evaluateExecution.set(true);
+            }
+        });
+        executableRuleGroup.addRule(ruleTrue);
+        executableRuleGroup.addRule(ruleTrueToo);
+        rules.register(executableRuleGroup);
+
+        // when
+        rulesEngine.fire(rules, facts);
+
+        // then
+        assertThat(evaluateExecution.get()).isTrue();
+    }
+
+    @Test
+    public void compositeRuleAndComposingRulesMustBeExecuted() throws Exception {
+        // given
+        final AtomicBoolean evaluateExecution = new AtomicBoolean(false);
+        executableRuleGroup = new ExecutableRuleGroup(new Action() {
+            @Override
+            public void execute(Facts facts) {
+                evaluateExecution.set(true);
+            }
+        });
+        executableRuleGroup.addRule(ruleTrue);
+        executableRuleGroup.addRule(ruleTrueToo);
+        rules.register(executableRuleGroup);
+
+        // when
+        rulesEngine.fire(rules, facts);
+
+        // then
+        assertThat(evaluateExecution.get()).isTrue();
+        verify(ruleTrueToo).execute(facts);
+        verify(ruleTrue).execute(facts);
+    }
+}


### PR DESCRIPTION
I realize that this functionality could be achieved by cleverly using the basic rules. But this didn't work in the way I was using the library. I was constructing complex rules out of a standard set of basic rules, but I needed a customizable action attached to the complex rule. 

Constructed this for a research project, thought it might do some good here too.