### PR TITLE
removing unnecessary toString calls in logging

### DIFF
--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/DefaultRulesEngine.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/DefaultRulesEngine.java
@@ -136,7 +136,7 @@ public final class DefaultRulesEngine extends AbstractRulesEngine {
     }
 
     private void logEngineParameters() {
-        LOGGER.debug(parameters.toString());
+        LOGGER.debug("{}", parameters);
     }
 
     private void log(Rules rules) {
@@ -150,7 +150,7 @@ public final class DefaultRulesEngine extends AbstractRulesEngine {
     private void log(Facts facts) {
         LOGGER.debug("Known facts:");
         for (Fact<?> fact : facts) {
-            LOGGER.debug(fact.toString());
+            LOGGER.debug("{}", fact);
         }
     }
 


### PR DESCRIPTION
There was unconditional call for toString() for all facts when calling DefaultRulesEngine#fire. 
I don't know if it is necessary to add test for that :)