### PR TITLE
Replace System Rules with System Lambda

### DIFF
--- a/easy-rules-mvel/pom.xml
+++ b/easy-rules-mvel/pom.xml
@@ -86,8 +86,8 @@
         </dependency>
         <dependency>
             <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-rules</artifactId>
-            <version>${system-rules.version}</version>
+            <artifactId>system-lambda</artifactId>
+            <version>${system-lambda.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/easy-rules-mvel/src/test/java/org/jeasy/rules/mvel/MVELActionTest.java
+++ b/easy-rules-mvel/src/test/java/org/jeasy/rules/mvel/MVELActionTest.java
@@ -25,18 +25,14 @@ package org.jeasy.rules.mvel;
 
 import org.jeasy.rules.api.Action;
 import org.jeasy.rules.api.Facts;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.mvel2.ParserContext;
 
+import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOutNormalized;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class MVELActionTest {
-
-    @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog();
 
     @Test
     public void testMVELActionExecution() throws Exception {
@@ -60,10 +56,11 @@ public class MVELActionTest {
         Facts facts = new Facts();
 
         // when
-        printAction.execute(facts);
+        String output = tapSystemOutNormalized(
+                () -> printAction.execute(facts));
 
         // then
-        assertThat(systemOutRule.getLog()).contains("Hello from MVEL!");
+        assertThat(output).isEqualTo("Hello from MVEL!\n");
     }
 
     @Test
@@ -90,10 +87,11 @@ public class MVELActionTest {
         Facts facts = new Facts();
 
         // when
-        printAction.execute(facts);
+        String output = tapSystemOutNormalized(
+                () -> printAction.execute(facts));
 
         // then
-        assertThat(systemOutRule.getLog()).contains("Random from MVEL = 2");
+        assertThat(output).isEqualTo("Random from MVEL = 2\n");
 
     }
 }

--- a/easy-rules-spel/pom.xml
+++ b/easy-rules-spel/pom.xml
@@ -102,8 +102,8 @@
         </dependency>
         <dependency>
             <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-rules</artifactId>
-            <version>${system-rules.version}</version>
+            <artifactId>system-lambda</artifactId>
+            <version>${system-lambda.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/easy-rules-spel/src/test/java/org/jeasy/rules/spel/SpELActionTest.java
+++ b/easy-rules-spel/src/test/java/org/jeasy/rules/spel/SpELActionTest.java
@@ -25,19 +25,15 @@ package org.jeasy.rules.spel;
 
 import org.jeasy.rules.api.Action;
 import org.jeasy.rules.api.Facts;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.springframework.expression.ParserContext;
 import org.springframework.expression.common.TemplateParserContext;
 
+import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOutNormalized;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class SpELActionTest {
-
-    @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog();
 
     @Test
     public void testSpELActionExecution() throws Exception {
@@ -61,10 +57,11 @@ public class SpELActionTest {
         Facts facts = new Facts();
 
         // when
-        printAction.execute(facts);
+        String output = tapSystemOutNormalized(
+                () -> printAction.execute(facts));
 
         // then
-        assertThat(systemOutRule.getLog()).contains("hello");
+        assertThat(output).isEqualTo("hello\n");
     }
 
     @Test
@@ -90,10 +87,11 @@ public class SpELActionTest {
         Facts facts = new Facts();
 
         // when
-        printAction.execute(facts);
+        String output = tapSystemOutNormalized(
+                () -> printAction.execute(facts));
 
         // then
-        assertThat(systemOutRule.getLog()).contains("hello");
+        assertThat(output).isEqualTo("hello\n");
 
     }
 }

--- a/easy-rules-spel/src/test/java/org/jeasy/rules/spel/SpELConditionTest.java
+++ b/easy-rules-spel/src/test/java/org/jeasy/rules/spel/SpELConditionTest.java
@@ -26,15 +26,14 @@ package org.jeasy.rules.spel;
 import org.assertj.core.api.Assertions;
 import org.jeasy.rules.api.Condition;
 import org.jeasy.rules.api.Facts;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.expression.BeanResolver;
 import org.springframework.expression.ParserContext;
 import org.springframework.expression.common.TemplateParserContext;
 
+import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOutNormalized;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SpELConditionTest {
@@ -80,9 +79,6 @@ public class SpELConditionTest {
         assertThat(evaluationResult).isTrue();
     }
 
-    @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog();
-
     @Test
     public void testSpELConditionWithExpressionAndParserContextAndBeanResolver() throws Exception {
 
@@ -103,8 +99,9 @@ public class SpELConditionTest {
         boolean evaluationResult = spELRule.evaluate(facts);
         Assertions.assertThat(evaluationResult).isTrue();
 
-        spELRule.execute(facts);
-        Assertions.assertThat(systemOutRule.getLog()).contains("Bonjour jack!");
+        String output = tapSystemOutNormalized(
+                () -> spELRule.execute(facts));
+        assertThat(output).isEqualTo("Bonjour jack!\n");
 
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <junit.version>4.13</junit.version>
         <assertj.version>3.16.0</assertj.version>
         <mockito.version>3.3.3</mockito.version>
-        <system-rules.version>1.19.0</system-rules.version>
+        <system-lambda.version>1.1.0</system-lambda.version>
         <slf4j.version>1.7.30</slf4j.version>
         <jackson.version>2.11.0</jackson.version>
         <maven-cobertura-plugin.version>2.7</maven-cobertura-plugin.version>


### PR DESCRIPTION
System Lambda is more specific. It only wraps the part of the code that
writes to System.out. In addition System Lambda is independent from the
test framework and no obstacle for moving to another test framework
(e.g. JUnit Lambda).

The assertions have been changed from "contains" to "isEqualTo" because
SystemLambda's "tapSystemOutNormalized" takes care about normalizing the
new line chars so that the returned String is the same on all OS.