### PR TITLE
Fix to Issue #377 - Added triggerListenersAfterEvaluate call in DefaultRuleEngine check

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2021 Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+Copyright (c) 2022 Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-archetype/pom.xml
+++ b/easy-rules-archetype/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.jeasy</groupId>
         <artifactId>easy-rules</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.1.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/easy-rules-core/pom.xml
+++ b/easy-rules-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jeasy</groupId>
         <artifactId>easy-rules</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>easy-rules-core</artifactId>

--- a/easy-rules-core/src/main/java/org/jeasy/rules/annotation/Action.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/annotation/Action.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/annotation/Action.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/annotation/Action.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/annotation/Condition.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/annotation/Condition.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/annotation/Condition.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/annotation/Condition.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/annotation/Fact.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/annotation/Fact.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/annotation/Fact.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/annotation/Fact.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/annotation/Priority.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/annotation/Priority.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/annotation/Priority.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/annotation/Priority.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/annotation/Rule.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/annotation/Rule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/annotation/Rule.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/annotation/Rule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/annotation/package-info.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/annotation/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/annotation/package-info.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/annotation/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/Action.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/Action.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/Action.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/Action.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/Condition.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/Condition.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/Condition.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/Condition.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/Fact.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/Fact.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/Fact.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/Fact.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/Facts.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/Facts.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/Facts.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/Facts.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/Rule.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/Rule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/Rule.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/Rule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/RuleListener.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/RuleListener.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/RuleListener.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/RuleListener.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/Rules.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/Rules.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/Rules.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/Rules.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/RulesEngine.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/RulesEngine.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/RulesEngine.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/RulesEngine.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/RulesEngineListener.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/RulesEngineListener.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/RulesEngineListener.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/RulesEngineListener.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/RulesEngineParameters.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/RulesEngineParameters.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/RulesEngineParameters.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/RulesEngineParameters.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/package-info.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/package-info.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/AbstractRulesEngine.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/AbstractRulesEngine.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/AbstractRulesEngine.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/AbstractRulesEngine.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/ActionMethodOrderBean.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/ActionMethodOrderBean.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/ActionMethodOrderBean.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/ActionMethodOrderBean.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/BasicRule.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/BasicRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/BasicRule.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/BasicRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/DefaultRule.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/DefaultRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/DefaultRule.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/DefaultRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/DefaultRulesEngine.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/DefaultRulesEngine.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal
@@ -172,7 +172,9 @@ public final class DefaultRulesEngine extends AbstractRulesEngine {
         Map<Rule, Boolean> result = new HashMap<>();
         for (Rule rule : rules) {
             if (shouldBeEvaluated(rule, facts)) {
-                result.put(rule, rule.evaluate(facts));
+                boolean res =  rule.evaluate(facts);
+            	result.put(rule, res);
+            	triggerListenersAfterEvaluate(rule, facts, res);
             }
         }
         return result;

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/DefaultRulesEngine.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/DefaultRulesEngine.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/InferenceRulesEngine.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/InferenceRulesEngine.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/InferenceRulesEngine.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/InferenceRulesEngine.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/NoSuchFactException.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/NoSuchFactException.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/NoSuchFactException.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/NoSuchFactException.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/RuleBuilder.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/RuleBuilder.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/RuleBuilder.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/RuleBuilder.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/RuleDefinitionValidator.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/RuleDefinitionValidator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/RuleDefinitionValidator.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/RuleDefinitionValidator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/RuleProxy.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/RuleProxy.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/RuleProxy.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/RuleProxy.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/Utils.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/Utils.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/Utils.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/Utils.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/package-info.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/main/java/org/jeasy/rules/core/package-info.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/core/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithActionMethodHavingMoreThanOneArgumentOfTypeFacts.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithActionMethodHavingMoreThanOneArgumentOfTypeFacts.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithActionMethodHavingMoreThanOneArgumentOfTypeFacts.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithActionMethodHavingMoreThanOneArgumentOfTypeFacts.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithActionMethodHavingOneArgumentNotOfTypeFacts.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithActionMethodHavingOneArgumentNotOfTypeFacts.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithActionMethodHavingOneArgumentNotOfTypeFacts.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithActionMethodHavingOneArgumentNotOfTypeFacts.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithActionMethodHavingOneArgumentOfTypeFacts.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithActionMethodHavingOneArgumentOfTypeFacts.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithActionMethodHavingOneArgumentOfTypeFacts.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithActionMethodHavingOneArgumentOfTypeFacts.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithActionMethodThatReturnsNonVoidType.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithActionMethodThatReturnsNonVoidType.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithActionMethodThatReturnsNonVoidType.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithActionMethodThatReturnsNonVoidType.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithConditionMethodHavingNonBooleanReturnType.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithConditionMethodHavingNonBooleanReturnType.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithConditionMethodHavingNonBooleanReturnType.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithConditionMethodHavingNonBooleanReturnType.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithConditionMethodHavingOneArgumentNotOfTypeFacts.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithConditionMethodHavingOneArgumentNotOfTypeFacts.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithConditionMethodHavingOneArgumentNotOfTypeFacts.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithConditionMethodHavingOneArgumentNotOfTypeFacts.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithMetaRuleAnnotation.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithMetaRuleAnnotation.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithMetaRuleAnnotation.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithMetaRuleAnnotation.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithMoreThanOnePriorityMethod.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithMoreThanOnePriorityMethod.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithMoreThanOnePriorityMethod.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithMoreThanOnePriorityMethod.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithMultipleAnnotatedParametersAndOneParameterOfSubTypeFacts.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithMultipleAnnotatedParametersAndOneParameterOfSubTypeFacts.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithMultipleAnnotatedParametersAndOneParameterOfSubTypeFacts.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithMultipleAnnotatedParametersAndOneParameterOfSubTypeFacts.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithMultipleAnnotatedParametersAndOneParameterOfTypeFacts.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithMultipleAnnotatedParametersAndOneParameterOfTypeFacts.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithMultipleAnnotatedParametersAndOneParameterOfTypeFacts.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithMultipleAnnotatedParametersAndOneParameterOfTypeFacts.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithNonPublicActionMethod.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithNonPublicActionMethod.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithNonPublicActionMethod.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithNonPublicActionMethod.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithNonPublicConditionMethod.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithNonPublicConditionMethod.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithNonPublicConditionMethod.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithNonPublicConditionMethod.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithNonPublicPriorityMethod.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithNonPublicPriorityMethod.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithNonPublicPriorityMethod.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithNonPublicPriorityMethod.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithOneParameterNotAnnotatedWithFactAndNotOfTypeFacts.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithOneParameterNotAnnotatedWithFactAndNotOfTypeFacts.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithOneParameterNotAnnotatedWithFactAndNotOfTypeFacts.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithOneParameterNotAnnotatedWithFactAndNotOfTypeFacts.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithPriorityMethodHavingArguments.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithPriorityMethodHavingArguments.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithPriorityMethodHavingArguments.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithPriorityMethodHavingArguments.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithPriorityMethodHavingNonIntegerReturnType.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithPriorityMethodHavingNonIntegerReturnType.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithPriorityMethodHavingNonIntegerReturnType.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithPriorityMethodHavingNonIntegerReturnType.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithoutActionMethod.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithoutActionMethod.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithoutActionMethod.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithoutActionMethod.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithoutConditionMethod.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithoutConditionMethod.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithoutConditionMethod.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/AnnotatedRuleWithoutConditionMethod.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/MetaRule.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/MetaRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/annotation/MetaRule.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/annotation/MetaRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/api/FactsTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/api/FactsTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/api/FactsTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/api/FactsTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/api/RulesTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/api/RulesTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/api/RulesTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/api/RulesTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/AbstractTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/AbstractTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/AbstractTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/AbstractTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/AnnotationInheritanceTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/AnnotationInheritanceTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/AnnotationInheritanceTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/AnnotationInheritanceTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/BasicRuleTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/BasicRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/BasicRuleTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/BasicRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/CustomRuleOrderingTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/CustomRuleOrderingTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/CustomRuleOrderingTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/CustomRuleOrderingTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/DefaultRuleTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/DefaultRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/DefaultRuleTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/DefaultRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/DefaultRulesEngineTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/DefaultRulesEngineTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/DefaultRulesEngineTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/DefaultRulesEngineTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/FactInjectionTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/FactInjectionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/FactInjectionTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/FactInjectionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/InferenceRulesEngineTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/InferenceRulesEngineTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/InferenceRulesEngineTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/InferenceRulesEngineTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/MissingFactAnnotationParameterTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/MissingFactAnnotationParameterTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/MissingFactAnnotationParameterTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/MissingFactAnnotationParameterTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/RuleBuilderTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/RuleBuilderTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/RuleBuilderTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/RuleBuilderTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/RuleDefinitionValidatorTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/RuleDefinitionValidatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/RuleDefinitionValidatorTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/RuleDefinitionValidatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/RuleListenerTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/RuleListenerTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal
@@ -136,5 +136,31 @@ public class RuleListenerTest extends AbstractTest {
         // Then
         verify(ruleListener1).afterEvaluate(rule1, facts, false);
     }
+    
+    @Test
+    public void whenTheRuleEvaluatesToFalseInDoCheck_thenTheListenerShouldBeInvoked() {
+        // Given
+        when(rule1.evaluate(facts)).thenReturn(false);
+        rules.register(rule1);
 
+        // When
+        rulesEngine.check(rules, facts);
+
+        // Then
+        verify(ruleListener1).afterEvaluate(rule1, facts, false);
+    }
+    
+    @Test
+    public void whenTheRuleEvaluatesToTrueInDoCheck_thenTheListenerShouldBeInvoked() {
+        // Given
+        when(rule1.evaluate(facts)).thenReturn(true);
+        rules.register(rule1);
+
+        // When
+        rulesEngine.check(rules, facts);
+
+        // Then
+        verify(ruleListener1).afterEvaluate(rule1, facts, true);
+    }
+    
 }

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/RuleListenerTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/RuleListenerTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/RulePriorityThresholdTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/RulePriorityThresholdTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/RulePriorityThresholdTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/RulePriorityThresholdTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/RuleProxyTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/RuleProxyTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/RuleProxyTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/RuleProxyTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/RulesEngineListenerTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/RulesEngineListenerTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/RulesEngineListenerTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/RulesEngineListenerTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/SkipOnFirstAppliedRuleTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/SkipOnFirstAppliedRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/SkipOnFirstAppliedRuleTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/SkipOnFirstAppliedRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/SkipOnFirstFailedRuleTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/SkipOnFirstFailedRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/SkipOnFirstFailedRuleTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/SkipOnFirstFailedRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/SkipOnFirstNonTriggeredRuleTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/SkipOnFirstNonTriggeredRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/SkipOnFirstNonTriggeredRuleTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/SkipOnFirstNonTriggeredRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/UtilsTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/UtilsTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/UtilsTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/UtilsTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-jexl/pom.xml
+++ b/easy-rules-jexl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jeasy</groupId>
         <artifactId>easy-rules</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>easy-rules-jexl</artifactId>

--- a/easy-rules-jexl/src/main/java/org/jeasy/rules/jexl/JexlAction.java
+++ b/easy-rules-jexl/src/main/java/org/jeasy/rules/jexl/JexlAction.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-jexl/src/main/java/org/jeasy/rules/jexl/JexlAction.java
+++ b/easy-rules-jexl/src/main/java/org/jeasy/rules/jexl/JexlAction.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-jexl/src/main/java/org/jeasy/rules/jexl/JexlCondition.java
+++ b/easy-rules-jexl/src/main/java/org/jeasy/rules/jexl/JexlCondition.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-jexl/src/main/java/org/jeasy/rules/jexl/JexlCondition.java
+++ b/easy-rules-jexl/src/main/java/org/jeasy/rules/jexl/JexlCondition.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-jexl/src/main/java/org/jeasy/rules/jexl/JexlRule.java
+++ b/easy-rules-jexl/src/main/java/org/jeasy/rules/jexl/JexlRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-jexl/src/main/java/org/jeasy/rules/jexl/JexlRule.java
+++ b/easy-rules-jexl/src/main/java/org/jeasy/rules/jexl/JexlRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-jexl/src/main/java/org/jeasy/rules/jexl/JexlRuleFactory.java
+++ b/easy-rules-jexl/src/main/java/org/jeasy/rules/jexl/JexlRuleFactory.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-jexl/src/main/java/org/jeasy/rules/jexl/JexlRuleFactory.java
+++ b/easy-rules-jexl/src/main/java/org/jeasy/rules/jexl/JexlRuleFactory.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-jexl/src/main/java/org/jeasy/rules/jexl/package-info.java
+++ b/easy-rules-jexl/src/main/java/org/jeasy/rules/jexl/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-jexl/src/main/java/org/jeasy/rules/jexl/package-info.java
+++ b/easy-rules-jexl/src/main/java/org/jeasy/rules/jexl/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-jexl/src/test/java/org/jeasy/rules/jexl/JexlActionTest.java
+++ b/easy-rules-jexl/src/test/java/org/jeasy/rules/jexl/JexlActionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-jexl/src/test/java/org/jeasy/rules/jexl/JexlActionTest.java
+++ b/easy-rules-jexl/src/test/java/org/jeasy/rules/jexl/JexlActionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-jexl/src/test/java/org/jeasy/rules/jexl/JexlConditionTest.java
+++ b/easy-rules-jexl/src/test/java/org/jeasy/rules/jexl/JexlConditionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-jexl/src/test/java/org/jeasy/rules/jexl/JexlConditionTest.java
+++ b/easy-rules-jexl/src/test/java/org/jeasy/rules/jexl/JexlConditionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-jexl/src/test/java/org/jeasy/rules/jexl/JexlRuleFactoryTest.java
+++ b/easy-rules-jexl/src/test/java/org/jeasy/rules/jexl/JexlRuleFactoryTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-jexl/src/test/java/org/jeasy/rules/jexl/JexlRuleFactoryTest.java
+++ b/easy-rules-jexl/src/test/java/org/jeasy/rules/jexl/JexlRuleFactoryTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-jexl/src/test/java/org/jeasy/rules/jexl/JexlRuleTest.java
+++ b/easy-rules-jexl/src/test/java/org/jeasy/rules/jexl/JexlRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-jexl/src/test/java/org/jeasy/rules/jexl/JexlRuleTest.java
+++ b/easy-rules-jexl/src/test/java/org/jeasy/rules/jexl/JexlRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-jexl/src/test/java/org/jeasy/rules/jexl/Person.java
+++ b/easy-rules-jexl/src/test/java/org/jeasy/rules/jexl/Person.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-jexl/src/test/java/org/jeasy/rules/jexl/Person.java
+++ b/easy-rules-jexl/src/test/java/org/jeasy/rules/jexl/Person.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-mvel/pom.xml
+++ b/easy-rules-mvel/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jeasy</groupId>
         <artifactId>easy-rules</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>easy-rules-mvel</artifactId>

--- a/easy-rules-mvel/src/main/java/org/jeasy/rules/mvel/MVELAction.java
+++ b/easy-rules-mvel/src/main/java/org/jeasy/rules/mvel/MVELAction.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-mvel/src/main/java/org/jeasy/rules/mvel/MVELAction.java
+++ b/easy-rules-mvel/src/main/java/org/jeasy/rules/mvel/MVELAction.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-mvel/src/main/java/org/jeasy/rules/mvel/MVELCondition.java
+++ b/easy-rules-mvel/src/main/java/org/jeasy/rules/mvel/MVELCondition.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-mvel/src/main/java/org/jeasy/rules/mvel/MVELCondition.java
+++ b/easy-rules-mvel/src/main/java/org/jeasy/rules/mvel/MVELCondition.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-mvel/src/main/java/org/jeasy/rules/mvel/MVELRule.java
+++ b/easy-rules-mvel/src/main/java/org/jeasy/rules/mvel/MVELRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-mvel/src/main/java/org/jeasy/rules/mvel/MVELRule.java
+++ b/easy-rules-mvel/src/main/java/org/jeasy/rules/mvel/MVELRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-mvel/src/main/java/org/jeasy/rules/mvel/MVELRuleFactory.java
+++ b/easy-rules-mvel/src/main/java/org/jeasy/rules/mvel/MVELRuleFactory.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-mvel/src/main/java/org/jeasy/rules/mvel/MVELRuleFactory.java
+++ b/easy-rules-mvel/src/main/java/org/jeasy/rules/mvel/MVELRuleFactory.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-mvel/src/main/java/org/jeasy/rules/mvel/package-info.java
+++ b/easy-rules-mvel/src/main/java/org/jeasy/rules/mvel/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-mvel/src/main/java/org/jeasy/rules/mvel/package-info.java
+++ b/easy-rules-mvel/src/main/java/org/jeasy/rules/mvel/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-mvel/src/test/java/org/jeasy/rules/mvel/MVELActionTest.java
+++ b/easy-rules-mvel/src/test/java/org/jeasy/rules/mvel/MVELActionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-mvel/src/test/java/org/jeasy/rules/mvel/MVELActionTest.java
+++ b/easy-rules-mvel/src/test/java/org/jeasy/rules/mvel/MVELActionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-mvel/src/test/java/org/jeasy/rules/mvel/MVELConditionTest.java
+++ b/easy-rules-mvel/src/test/java/org/jeasy/rules/mvel/MVELConditionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-mvel/src/test/java/org/jeasy/rules/mvel/MVELConditionTest.java
+++ b/easy-rules-mvel/src/test/java/org/jeasy/rules/mvel/MVELConditionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-mvel/src/test/java/org/jeasy/rules/mvel/MVELRuleFactoryTest.java
+++ b/easy-rules-mvel/src/test/java/org/jeasy/rules/mvel/MVELRuleFactoryTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-mvel/src/test/java/org/jeasy/rules/mvel/MVELRuleFactoryTest.java
+++ b/easy-rules-mvel/src/test/java/org/jeasy/rules/mvel/MVELRuleFactoryTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-mvel/src/test/java/org/jeasy/rules/mvel/MVELRuleTest.java
+++ b/easy-rules-mvel/src/test/java/org/jeasy/rules/mvel/MVELRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-mvel/src/test/java/org/jeasy/rules/mvel/MVELRuleTest.java
+++ b/easy-rules-mvel/src/test/java/org/jeasy/rules/mvel/MVELRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-mvel/src/test/java/org/jeasy/rules/mvel/Person.java
+++ b/easy-rules-mvel/src/test/java/org/jeasy/rules/mvel/Person.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-mvel/src/test/java/org/jeasy/rules/mvel/Person.java
+++ b/easy-rules-mvel/src/test/java/org/jeasy/rules/mvel/Person.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-spel/pom.xml
+++ b/easy-rules-spel/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jeasy</groupId>
         <artifactId>easy-rules</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>easy-rules-spel</artifactId>

--- a/easy-rules-spel/src/main/java/org/jeasy/rules/spel/SpELAction.java
+++ b/easy-rules-spel/src/main/java/org/jeasy/rules/spel/SpELAction.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-spel/src/main/java/org/jeasy/rules/spel/SpELAction.java
+++ b/easy-rules-spel/src/main/java/org/jeasy/rules/spel/SpELAction.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-spel/src/main/java/org/jeasy/rules/spel/SpELCondition.java
+++ b/easy-rules-spel/src/main/java/org/jeasy/rules/spel/SpELCondition.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-spel/src/main/java/org/jeasy/rules/spel/SpELCondition.java
+++ b/easy-rules-spel/src/main/java/org/jeasy/rules/spel/SpELCondition.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-spel/src/main/java/org/jeasy/rules/spel/SpELRule.java
+++ b/easy-rules-spel/src/main/java/org/jeasy/rules/spel/SpELRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-spel/src/main/java/org/jeasy/rules/spel/SpELRule.java
+++ b/easy-rules-spel/src/main/java/org/jeasy/rules/spel/SpELRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-spel/src/main/java/org/jeasy/rules/spel/SpELRuleFactory.java
+++ b/easy-rules-spel/src/main/java/org/jeasy/rules/spel/SpELRuleFactory.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-spel/src/main/java/org/jeasy/rules/spel/SpELRuleFactory.java
+++ b/easy-rules-spel/src/main/java/org/jeasy/rules/spel/SpELRuleFactory.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-spel/src/main/java/org/jeasy/rules/spel/package-info.java
+++ b/easy-rules-spel/src/main/java/org/jeasy/rules/spel/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-spel/src/main/java/org/jeasy/rules/spel/package-info.java
+++ b/easy-rules-spel/src/main/java/org/jeasy/rules/spel/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-spel/src/test/java/org/jeasy/rules/spel/Greeter.java
+++ b/easy-rules-spel/src/test/java/org/jeasy/rules/spel/Greeter.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-spel/src/test/java/org/jeasy/rules/spel/Greeter.java
+++ b/easy-rules-spel/src/test/java/org/jeasy/rules/spel/Greeter.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-spel/src/test/java/org/jeasy/rules/spel/MySpringAppConfig.java
+++ b/easy-rules-spel/src/test/java/org/jeasy/rules/spel/MySpringAppConfig.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-spel/src/test/java/org/jeasy/rules/spel/MySpringAppConfig.java
+++ b/easy-rules-spel/src/test/java/org/jeasy/rules/spel/MySpringAppConfig.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-spel/src/test/java/org/jeasy/rules/spel/Person.java
+++ b/easy-rules-spel/src/test/java/org/jeasy/rules/spel/Person.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-spel/src/test/java/org/jeasy/rules/spel/Person.java
+++ b/easy-rules-spel/src/test/java/org/jeasy/rules/spel/Person.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-spel/src/test/java/org/jeasy/rules/spel/SimpleBeanResolver.java
+++ b/easy-rules-spel/src/test/java/org/jeasy/rules/spel/SimpleBeanResolver.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-spel/src/test/java/org/jeasy/rules/spel/SimpleBeanResolver.java
+++ b/easy-rules-spel/src/test/java/org/jeasy/rules/spel/SimpleBeanResolver.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-spel/src/test/java/org/jeasy/rules/spel/SpELActionTest.java
+++ b/easy-rules-spel/src/test/java/org/jeasy/rules/spel/SpELActionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-spel/src/test/java/org/jeasy/rules/spel/SpELActionTest.java
+++ b/easy-rules-spel/src/test/java/org/jeasy/rules/spel/SpELActionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-spel/src/test/java/org/jeasy/rules/spel/SpELConditionTest.java
+++ b/easy-rules-spel/src/test/java/org/jeasy/rules/spel/SpELConditionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-spel/src/test/java/org/jeasy/rules/spel/SpELConditionTest.java
+++ b/easy-rules-spel/src/test/java/org/jeasy/rules/spel/SpELConditionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-spel/src/test/java/org/jeasy/rules/spel/SpELRuleFactoryTest.java
+++ b/easy-rules-spel/src/test/java/org/jeasy/rules/spel/SpELRuleFactoryTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-spel/src/test/java/org/jeasy/rules/spel/SpELRuleFactoryTest.java
+++ b/easy-rules-spel/src/test/java/org/jeasy/rules/spel/SpELRuleFactoryTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-spel/src/test/java/org/jeasy/rules/spel/SpELRuleTest.java
+++ b/easy-rules-spel/src/test/java/org/jeasy/rules/spel/SpELRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-spel/src/test/java/org/jeasy/rules/spel/SpELRuleTest.java
+++ b/easy-rules-spel/src/test/java/org/jeasy/rules/spel/SpELRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-support/pom.xml
+++ b/easy-rules-support/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jeasy</groupId>
         <artifactId>easy-rules</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>easy-rules-support</artifactId>

--- a/easy-rules-support/src/main/java/org/jeasy/rules/support/AbstractRuleFactory.java
+++ b/easy-rules-support/src/main/java/org/jeasy/rules/support/AbstractRuleFactory.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-support/src/main/java/org/jeasy/rules/support/AbstractRuleFactory.java
+++ b/easy-rules-support/src/main/java/org/jeasy/rules/support/AbstractRuleFactory.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-support/src/main/java/org/jeasy/rules/support/RuleDefinition.java
+++ b/easy-rules-support/src/main/java/org/jeasy/rules/support/RuleDefinition.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-support/src/main/java/org/jeasy/rules/support/RuleDefinition.java
+++ b/easy-rules-support/src/main/java/org/jeasy/rules/support/RuleDefinition.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-support/src/main/java/org/jeasy/rules/support/composite/ActivationRuleGroup.java
+++ b/easy-rules-support/src/main/java/org/jeasy/rules/support/composite/ActivationRuleGroup.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-support/src/main/java/org/jeasy/rules/support/composite/ActivationRuleGroup.java
+++ b/easy-rules-support/src/main/java/org/jeasy/rules/support/composite/ActivationRuleGroup.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-support/src/main/java/org/jeasy/rules/support/composite/CompositeRule.java
+++ b/easy-rules-support/src/main/java/org/jeasy/rules/support/composite/CompositeRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-support/src/main/java/org/jeasy/rules/support/composite/CompositeRule.java
+++ b/easy-rules-support/src/main/java/org/jeasy/rules/support/composite/CompositeRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-support/src/main/java/org/jeasy/rules/support/composite/ConditionalRuleGroup.java
+++ b/easy-rules-support/src/main/java/org/jeasy/rules/support/composite/ConditionalRuleGroup.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-support/src/main/java/org/jeasy/rules/support/composite/ConditionalRuleGroup.java
+++ b/easy-rules-support/src/main/java/org/jeasy/rules/support/composite/ConditionalRuleGroup.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-support/src/main/java/org/jeasy/rules/support/composite/UnitRuleGroup.java
+++ b/easy-rules-support/src/main/java/org/jeasy/rules/support/composite/UnitRuleGroup.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-support/src/main/java/org/jeasy/rules/support/composite/UnitRuleGroup.java
+++ b/easy-rules-support/src/main/java/org/jeasy/rules/support/composite/UnitRuleGroup.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-support/src/main/java/org/jeasy/rules/support/reader/AbstractRuleDefinitionReader.java
+++ b/easy-rules-support/src/main/java/org/jeasy/rules/support/reader/AbstractRuleDefinitionReader.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-support/src/main/java/org/jeasy/rules/support/reader/AbstractRuleDefinitionReader.java
+++ b/easy-rules-support/src/main/java/org/jeasy/rules/support/reader/AbstractRuleDefinitionReader.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-support/src/main/java/org/jeasy/rules/support/reader/JsonRuleDefinitionReader.java
+++ b/easy-rules-support/src/main/java/org/jeasy/rules/support/reader/JsonRuleDefinitionReader.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-support/src/main/java/org/jeasy/rules/support/reader/JsonRuleDefinitionReader.java
+++ b/easy-rules-support/src/main/java/org/jeasy/rules/support/reader/JsonRuleDefinitionReader.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-support/src/main/java/org/jeasy/rules/support/reader/RuleDefinitionReader.java
+++ b/easy-rules-support/src/main/java/org/jeasy/rules/support/reader/RuleDefinitionReader.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-support/src/main/java/org/jeasy/rules/support/reader/RuleDefinitionReader.java
+++ b/easy-rules-support/src/main/java/org/jeasy/rules/support/reader/RuleDefinitionReader.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-support/src/main/java/org/jeasy/rules/support/reader/YamlRuleDefinitionReader.java
+++ b/easy-rules-support/src/main/java/org/jeasy/rules/support/reader/YamlRuleDefinitionReader.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-support/src/main/java/org/jeasy/rules/support/reader/YamlRuleDefinitionReader.java
+++ b/easy-rules-support/src/main/java/org/jeasy/rules/support/reader/YamlRuleDefinitionReader.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-support/src/test/java/org/jeasy/rules/support/composite/ActivationRuleGroupTest.java
+++ b/easy-rules-support/src/test/java/org/jeasy/rules/support/composite/ActivationRuleGroupTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-support/src/test/java/org/jeasy/rules/support/composite/ActivationRuleGroupTest.java
+++ b/easy-rules-support/src/test/java/org/jeasy/rules/support/composite/ActivationRuleGroupTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-support/src/test/java/org/jeasy/rules/support/composite/ConditionalRuleGroupTest.java
+++ b/easy-rules-support/src/test/java/org/jeasy/rules/support/composite/ConditionalRuleGroupTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-support/src/test/java/org/jeasy/rules/support/composite/ConditionalRuleGroupTest.java
+++ b/easy-rules-support/src/test/java/org/jeasy/rules/support/composite/ConditionalRuleGroupTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-support/src/test/java/org/jeasy/rules/support/composite/UnitRuleGroupTest.java
+++ b/easy-rules-support/src/test/java/org/jeasy/rules/support/composite/UnitRuleGroupTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-support/src/test/java/org/jeasy/rules/support/composite/UnitRuleGroupTest.java
+++ b/easy-rules-support/src/test/java/org/jeasy/rules/support/composite/UnitRuleGroupTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-support/src/test/java/org/jeasy/rules/support/reader/RuleDefinitionReaderTest.java
+++ b/easy-rules-support/src/test/java/org/jeasy/rules/support/reader/RuleDefinitionReaderTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-support/src/test/java/org/jeasy/rules/support/reader/RuleDefinitionReaderTest.java
+++ b/easy-rules-support/src/test/java/org/jeasy/rules/support/reader/RuleDefinitionReaderTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/pom.xml
+++ b/easy-rules-tutorials/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jeasy</groupId>
         <artifactId>easy-rules</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>easy-rules-tutorials</artifactId>

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/airco/DecreaseTemperatureAction.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/airco/DecreaseTemperatureAction.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/airco/DecreaseTemperatureAction.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/airco/DecreaseTemperatureAction.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/airco/HighTemperatureCondition.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/airco/HighTemperatureCondition.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/airco/HighTemperatureCondition.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/airco/HighTemperatureCondition.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/airco/Launcher.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/airco/Launcher.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/airco/Launcher.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/airco/Launcher.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/fizzbuzz/BuzzRule.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/fizzbuzz/BuzzRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/fizzbuzz/BuzzRule.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/fizzbuzz/BuzzRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/fizzbuzz/FizzBuzz.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/fizzbuzz/FizzBuzz.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/fizzbuzz/FizzBuzz.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/fizzbuzz/FizzBuzz.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/fizzbuzz/FizzBuzzRule.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/fizzbuzz/FizzBuzzRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/fizzbuzz/FizzBuzzRule.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/fizzbuzz/FizzBuzzRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/fizzbuzz/FizzBuzzWithEasyRules.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/fizzbuzz/FizzBuzzWithEasyRules.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/fizzbuzz/FizzBuzzWithEasyRules.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/fizzbuzz/FizzBuzzWithEasyRules.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/fizzbuzz/FizzRule.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/fizzbuzz/FizzRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/fizzbuzz/FizzRule.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/fizzbuzz/FizzRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/fizzbuzz/NonFizzBuzzRule.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/fizzbuzz/NonFizzBuzzRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/fizzbuzz/NonFizzBuzzRule.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/fizzbuzz/NonFizzBuzzRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/helloworld/HelloWorldRule.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/helloworld/HelloWorldRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/helloworld/HelloWorldRule.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/helloworld/HelloWorldRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/helloworld/Launcher.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/helloworld/Launcher.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/helloworld/Launcher.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/helloworld/Launcher.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/shop/Launcher.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/shop/Launcher.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/shop/Launcher.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/shop/Launcher.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/shop/Person.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/shop/Person.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/shop/Person.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/shop/Person.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/weather/Launcher.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/weather/Launcher.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/weather/Launcher.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/weather/Launcher.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/weather/WeatherRule.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/weather/WeatherRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/weather/WeatherRule.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/weather/WeatherRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/web/IndexServlet.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/web/IndexServlet.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/web/IndexServlet.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/web/IndexServlet.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/web/SuspiciousRequestFilter.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/web/SuspiciousRequestFilter.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/web/SuspiciousRequestFilter.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/web/SuspiciousRequestFilter.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/web/SuspiciousRequestRule.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/web/SuspiciousRequestRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/web/SuspiciousRequestRule.java
+++ b/easy-rules-tutorials/src/main/java/org/jeasy/rules/tutorials/web/SuspiciousRequestRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- *  Copyright (c) 2020, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *  Copyright (c) 2022, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.jeasy</groupId>
     <artifactId>easy-rules</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.1.2-SNAPSHOT</version>
 
     <modules>
         <module>easy-rules-archetype</module>
@@ -168,7 +168,7 @@
                     <version>${maven-license-plugin.version}</version>
                     <configuration>
                         <properties>
-                            <currentYear>2020</currentYear>
+                            <currentYear>2022</currentYear>
                         </properties>
                         <strictCheck>true</strictCheck>
                         <includes>

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
                     <version>${maven-license-plugin.version}</version>
                     <configuration>
                         <properties>
-                            <currentYear>2022</currentYear>
+                            <currentYear>2020</currentYear>
                         </properties>
                         <strictCheck>true</strictCheck>
                         <includes>

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
                     <version>${maven-license-plugin.version}</version>
                     <configuration>
                         <properties>
-                            <currentYear>2020</currentYear>
+                            <currentYear>2022</currentYear>
                         </properties>
                         <strictCheck>true</strictCheck>
                         <includes>


### PR DESCRIPTION
Added trigger triggerListenersAfterEvaluate after every rules evaluation in doCheck method. At the moment it was just called in fire method so, we were not able for example to remove a Fact after rules evaluation when using the check method.
Added related unit test in RuleListenerTest.