### PR TITLE
Allow rules to have optional facts (issue #390)

### DIFF
--- a/easy-rules-core/pom.xml
+++ b/easy-rules-core/pom.xml
@@ -77,6 +77,11 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/easy-rules-core/src/test/java/org/jeasy/rules/core/OptionalFactAnnotationParameterTest.java
+++ b/easy-rules-core/src/test/java/org/jeasy/rules/core/OptionalFactAnnotationParameterTest.java
@@ -1,0 +1,71 @@
+/*
+ * The MIT License
+ *
+ *  Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package org.jeasy.rules.core;
+
+import org.jeasy.rules.annotation.Action;
+import org.jeasy.rules.annotation.Condition;
+import org.jeasy.rules.annotation.Fact;
+import org.jeasy.rules.annotation.Rule;
+import org.jeasy.rules.api.Facts;
+import org.jeasy.rules.api.Rules;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+/**
+ * Null facts are not accepted by design, a declared fact can be missing though.
+ */
+public class OptionalFactAnnotationParameterTest extends AbstractTest {
+
+    @Test
+    public void testMissingFact() {
+        Rules rules = new Rules();
+        rules.register(new AnnotatedParametersRule());
+
+        Facts facts = new Facts();
+        facts.put("fact1", new Object());
+
+        Map<org.jeasy.rules.api.Rule, Boolean> results = rulesEngine.check(rules, facts);
+
+        for (boolean b : results.values()) {
+            Assert.assertTrue(b);
+        }
+    }
+
+    @Rule
+    public static class AnnotatedParametersRule {
+
+        @Condition
+        public boolean when(@Fact("fact1") Object fact1, @Nullable @Fact("fact2") Object fact2) {
+            return fact1 != null && fact2 == null;
+        }
+
+        @Action
+        public void then(@Fact("fact1") Object fact1, @Nullable @Fact("fact2") Object fact2) {
+        }
+
+    }
+}

--- a/licence-header-template.txt
+++ b/licence-header-template.txt
@@ -1,6 +1,6 @@
 The MIT License
 
- Copyright (c) ${currentYear}, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ Copyright (c) 2021, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <system-lambda.version>1.1.1</system-lambda.version>
         <slf4j.version>1.7.30</slf4j.version>
         <jackson.version>2.11.3</jackson.version>
+        <jsr305.version>3.0.2</jsr305.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
@@ -110,6 +111,12 @@
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+                <version>${jsr305.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
The current code prevents executing a rule if one of the facts listed in the parameters of the condition or the action is missing. It would be nice to be able to modify this behavior so that in some situations missing facts do not prevent the execution of the rule if they are specified as being optional (issue #390).

In this PR I take into account the `@Nullable` annotation on parameters to consider them as optional.

I know that easy-rules is in maintenance mode, so I'm not sure this PR will be reviewed and merger on master... Can you tell me if it's possible or if I should use a forked release for my needs ? Thanks in advance.