### PR TITLE
Implement Serializable For Rules

### DIFF
--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/Action.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/Action.java
@@ -23,13 +23,15 @@
  */
 package org.jeasy.rules.api;
 
+import java.io.Serializable;
+
 /**
  * This interface represents a rule's action.
  *
  * @author Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  */
 @FunctionalInterface
-public interface Action {
+public interface Action extends Serializable {
 
     /**
      * Execute the action when the rule's condition evaluates to true.

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/Condition.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/Condition.java
@@ -23,13 +23,15 @@
  */
 package org.jeasy.rules.api;
 
+import java.io.Serializable;
+
 /**
  * This interface represents a rule's condition.
  *
  * @author Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  */
 @FunctionalInterface
-public interface Condition {
+public interface Condition  extends Serializable {
 
     /**
      * Evaluate the condition according to the known facts.

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/Fact.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/Fact.java
@@ -23,6 +23,7 @@
  */
 package org.jeasy.rules.api;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /**
@@ -32,7 +33,7 @@ import java.util.Objects;
  * @param <T> type of the fact
  * @author Mahmoud Ben Hassine
  */
-public class Fact<T> {
+public class Fact<T> implements Serializable {
 	
 	private final String name;
 	private final T value;

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/Facts.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/Facts.java
@@ -23,6 +23,7 @@
  */
 package org.jeasy.rules.api;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -36,7 +37,7 @@ import java.util.Set;
  *
  * @author Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  */
-public class Facts implements Iterable<Fact<?>> {
+public class Facts implements Iterable<Fact<?>>, Serializable {
 
     private final Set<Fact<?>> facts = new HashSet<>();
 

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/Rule.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/Rule.java
@@ -23,6 +23,8 @@
  */
 package org.jeasy.rules.api;
 
+import java.io.Serializable;
+
 /**
  * Abstraction for a rule that can be fired by a rules engine.
  *
@@ -31,7 +33,7 @@ package org.jeasy.rules.api;
  *
  * @author Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  */
-public interface Rule extends Comparable<Rule> {
+public interface Rule extends Comparable<Rule>, Serializable {
 
     /**
      * Default rule name.

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/RuleListener.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/RuleListener.java
@@ -23,12 +23,14 @@
  */
 package org.jeasy.rules.api;
 
+import java.io.Serializable;
+
 /**
  * A listener for rule execution events.
  *
  * @author Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  */
-public interface RuleListener {
+public interface RuleListener extends Serializable {
 
     /**
      * Triggered before the evaluation of a rule.

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/Rules.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/Rules.java
@@ -25,6 +25,7 @@ package org.jeasy.rules.api;
 
 import org.jeasy.rules.core.RuleProxy;
 
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Objects;
@@ -41,7 +42,7 @@ import java.util.TreeSet;
  *
  * @author Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  */
-public class Rules implements Iterable<Rule> {
+public class Rules implements Iterable<Rule>, Serializable {
 
     private Set<Rule> rules = new TreeSet<>();
 

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/RulesEngineListener.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/RulesEngineListener.java
@@ -25,12 +25,14 @@ package org.jeasy.rules.api;
 
 import org.jeasy.rules.core.InferenceRulesEngine;
 
+import java.io.Serializable;
+
 /**
  * A listener for rules engine execution events.
  *
  * @author Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  */
-public interface RulesEngineListener {
+public interface RulesEngineListener extends Serializable {
 
     /**
      * Triggered before evaluating the rule set.

--- a/easy-rules-core/src/main/java/org/jeasy/rules/api/RulesEngineParameters.java
+++ b/easy-rules-core/src/main/java/org/jeasy/rules/api/RulesEngineParameters.java
@@ -26,6 +26,8 @@ package org.jeasy.rules.api;
 import org.jeasy.rules.core.DefaultRulesEngine;
 import org.jeasy.rules.core.InferenceRulesEngine;
 
+import java.io.Serializable;
+
 /**
  * Parameters of a rules engine.
  *
@@ -36,13 +38,13 @@ import org.jeasy.rules.core.InferenceRulesEngine;
  *
  * @author Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  */
-public class RulesEngineParameters {
+public class RulesEngineParameters implements Serializable {
 
     /**
      * Default rule priority threshold.
      */
     public static final int DEFAULT_RULE_PRIORITY_THRESHOLD = Integer.MAX_VALUE;
-    
+
     /**
      * Parameter to skip next applicable rules when a rule is applied.
      */
@@ -73,10 +75,10 @@ public class RulesEngineParameters {
     /**
      * Create a new {@link RulesEngineParameters}.
      *
-     * @param skipOnFirstAppliedRule parameter to skip next applicable rules on first applied rule.
-     * @param skipOnFirstFailedRule parameter to skip next applicable rules on first failed rule.
+     * @param skipOnFirstAppliedRule      parameter to skip next applicable rules on first applied rule.
+     * @param skipOnFirstFailedRule       parameter to skip next applicable rules on first failed rule.
      * @param skipOnFirstNonTriggeredRule parameter to skip next applicable rules on first non triggered rule.
-     * @param priorityThreshold threshold after which rules should be skipped.
+     * @param priorityThreshold           threshold after which rules should be skipped.
      */
     public RulesEngineParameters(final boolean skipOnFirstAppliedRule, final boolean skipOnFirstFailedRule, final boolean skipOnFirstNonTriggeredRule, final int priorityThreshold) {
         this.skipOnFirstAppliedRule = skipOnFirstAppliedRule;


### PR DESCRIPTION
 The objects needs to be serialized so that the data
 can be cached and stored instead of preparing it
 again and running through compilation process